### PR TITLE
Remove unused UploadResult import from product form

### DIFF
--- a/client/src/components/forms/product-form.tsx
+++ b/client/src/components/forms/product-form.tsx
@@ -11,7 +11,6 @@ import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 import { Product } from "@/lib/types";
 import { ObjectUploader } from "@/components/ObjectUploader";
-import type { UploadResult } from "@uppy/core";
 import { MarkdownRenderer } from "@/components/ui/markdown-renderer";
 import { Eye, FileText } from "lucide-react";
 import { useState } from "react";


### PR DESCRIPTION
## Summary
- remove the unused UploadResult type import from the product form component

## Testing
- npm run check *(fails: pre-existing type errors in offer-table and storage)*

------
https://chatgpt.com/codex/tasks/task_e_68d030ce69d8832ab88d60ecb0531152