### PR TITLE
Remove debug logging from product form

### DIFF
--- a/client/src/components/forms/product-form.tsx
+++ b/client/src/components/forms/product-form.tsx
@@ -114,13 +114,6 @@ export default function ProductForm({ product, onClose }: ProductFormProps) {
       displayImageUrl: latestDisplayImage,
     };
     
-    console.log('=== FORM SUBMISSION DEBUG ===');
-    console.log('Original form data:', data);
-    console.log('Latest images from form:', latestImages);
-    console.log('Latest display image:', latestDisplayImage);
-    console.log('Final form data being sent:', finalFormData);
-    console.log('================================');
-    
     createProductMutation.mutate(finalFormData);
   };
 
@@ -287,8 +280,6 @@ export default function ProductForm({ product, onClose }: ProductFormProps) {
                     description: `${newImages.length} image(s) added and ready for form submission`,
                   });
                   
-                  console.log('Images updated:', allImages);
-                  console.log('Form images value after update:', form.getValues("images"));
                 } else {
                   // Handle case where no files were uploaded successfully
                   setIsUploading(false);


### PR DESCRIPTION
## Summary
- remove debugging console.log statements from the product form submission handler and image upload callback
- keep existing user-visible toasts for upload and mutation feedback

## Testing
- npm run check *(fails: pre-existing type errors in client/src/components/admin/offer-table.tsx and server/storage.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d031fbd8a8832aaac90a8e17760304