### PR TITLE
Update auth fallback query key

### DIFF
--- a/client/src/components/auth/hybrid-login.tsx
+++ b/client/src/components/auth/hybrid-login.tsx
@@ -131,9 +131,9 @@ export default function HybridLogin({ userType, title, onSuccess }: HybridLoginP
     });
     
     // Invalidate auth queries based on user type
-    const authKey = userType === 'admin' ? '/api/admin/me' : 
-                   userType === 'influencer' ? '/api/influencer/me' : 
-                   '/api/auth/user';
+    const authKey = userType === 'admin' ? '/api/admin/me' :
+                   userType === 'influencer' ? '/api/influencer/me' :
+                   '/api/auth/me';
     
     queryClient.invalidateQueries({ queryKey: [authKey] });
     

--- a/client/src/components/auth/otp-login.tsx
+++ b/client/src/components/auth/otp-login.tsx
@@ -77,9 +77,9 @@ export default function OtpLogin({ userType, title, onSuccess }: OtpLoginProps) 
       });
       
       // Invalidate auth queries based on user type
-      const authKey = userType === 'admin' ? '/api/admin/me' : 
-                     userType === 'influencer' ? '/api/influencer/me' : 
-                     '/api/auth/user';
+      const authKey = userType === 'admin' ? '/api/admin/me' :
+                     userType === 'influencer' ? '/api/influencer/me' :
+                     '/api/auth/me';
       
       queryClient.invalidateQueries({ queryKey: [authKey] });
       


### PR DESCRIPTION
## Summary
- update the fallback auth query key in hybrid and OTP login flows to `/api/auth/me`
- align remaining client references to `/api/auth/me` so post-login invalidation hits the correct endpoint

## Testing
- npm run check *(fails: existing type errors in client/src/components/admin/offer-table.tsx and server/storage.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d03208f998832abba78f4f10f56d5f