### PR TITLE
Persist applied offer for checkout

### DIFF
--- a/client/src/pages/cart.tsx
+++ b/client/src/pages/cart.tsx
@@ -1,4 +1,4 @@
-import { useQuery, useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useCart } from "@/hooks/use-cart";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -8,16 +8,27 @@ import { useLocation } from "wouter";
 import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 import { ArrowLeft } from "lucide-react";
+import type { Offer } from "@/lib/types";
 
 export default function Cart() {
   const [, setLocation] = useLocation();
   const { toast } = useToast();
   const [couponCode, setCouponCode] = useState("");
-  const [appliedOffer, setAppliedOffer] = useState<any>(null);
+  const [appliedOffer, setAppliedOffer] = useState<Offer | null>(null);
   const [couponError, setCouponError] = useState("");
   const [shippingCharge, setShippingCharge] = useState(50); // Default shipping
   const [isCalculatingShipping, setIsCalculatingShipping] = useState(false);
   const { cartItems, isLoading, subtotal } = useCart();
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    queryClient.setQueryData(
+      ["checkout", "selectedOffer"],
+      appliedOffer
+        ? { id: appliedOffer.id, code: appliedOffer.code }
+        : null
+    );
+  }, [appliedOffer, queryClient]);
 
   // Calculate shipping charge when cart changes
   useEffect(() => {

--- a/client/src/pages/checkout.tsx
+++ b/client/src/pages/checkout.tsx
@@ -229,10 +229,16 @@ export default function Checkout() {
         await createAddressMutation.mutateAsync(addressData);
       }
 
+      const selectedOffer = queryClient.getQueryData<{ id: string; code: string } | null>([
+        "checkout",
+        "selectedOffer"
+      ]);
+
       const response = await apiRequest("POST", "/api/orders", {
         userId: user.id,
         userInfo,
         paymentMethod,
+        offerCode: selectedOffer?.code ?? null,
       });
       return await response.json();
     },
@@ -241,6 +247,7 @@ export default function Checkout() {
       clearCart.mutate();
       // Invalidate orders cache to show the new order
       queryClient.invalidateQueries({ queryKey: ["/api/auth/orders"] });
+      queryClient.setQueryData(["checkout", "selectedOffer"], null);
       // Store order data in session storage for thank you page
       sessionStorage.setItem('lastOrder', JSON.stringify({
         orderId: data.order.id,

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -441,7 +441,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       pincode: z.string().min(1, 'Pincode is required'),
       makePreferred: z.boolean().optional().default(false),
     }).optional(),
-    offerId: z.string().optional().nullable(),
+    offerCode: z.string().optional().nullable(),
     paymentMethod: z.string().min(1, 'Payment method is required'),
     selectedAddressId: z.string().optional().nullable(),
   });
@@ -456,7 +456,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     try {
       // Validate request body
       const validatedData = orderCreationSchema.parse(req.body);
-      const { userInfo, offerId, paymentMethod, selectedAddressId } = validatedData;
+      const { userInfo, offerCode, paymentMethod, selectedAddressId } = validatedData;
       const userId = req.session.userId; // Use authenticated user ID
       
       const cartItems = await storage.getCartItems(req.session.sessionId!);
@@ -545,19 +545,17 @@ export async function registerRoutes(app: Express): Promise<Server> {
       // Calculate totals
       const subtotal = cartItems.reduce((sum, item) => sum + (parseFloat(item.product.price) * item.quantity), 0);
       let discountAmount = 0;
+      const appliedOffer = offerCode ? await storage.getOfferByCode(offerCode) : undefined;
 
       // Apply offer if provided
-      if (offerId) {
-        const offer = await storage.getOfferByCode(offerId);
-        if (offer) {
-          if (offer.discountType === 'percentage') {
-            discountAmount = (subtotal * parseFloat(offer.discountValue)) / 100;
-            if (offer.maxDiscount) {
-              discountAmount = Math.min(discountAmount, parseFloat(offer.maxDiscount));
-            }
-          } else {
-            discountAmount = parseFloat(offer.discountValue);
+      if (appliedOffer) {
+        if (appliedOffer.discountType === 'percentage') {
+          discountAmount = (subtotal * parseFloat(appliedOffer.discountValue)) / 100;
+          if (appliedOffer.maxDiscount) {
+            discountAmount = Math.min(discountAmount, parseFloat(appliedOffer.maxDiscount));
           }
+        } else {
+          discountAmount = parseFloat(appliedOffer.discountValue);
         }
       }
 
@@ -581,7 +579,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         discountAmount: discountAmount.toString(),
         shippingCharge: shippingCharge.toString(),
         total: total.toString(),
-        offerId: offerId || undefined,
+        offerId: appliedOffer?.id,
         paymentMethod,
         paymentStatus: 'completed', // Mock successful payment
         status: 'confirmed',
@@ -600,17 +598,14 @@ export async function registerRoutes(app: Express): Promise<Server> {
       await storage.createOrderItems(orderItems);
 
       // Create offer redemption if offer was used
-      if (offerId) {
-        const offer = await storage.getOfferByCode(offerId);
-        if (offer) {
-          await storage.createOfferRedemption({
-            offerId: offer.id,
-            userId,
-            orderId: order.id,
-            discountAmount: discountAmount.toString(),
-          });
-          await storage.incrementOfferUsage(offer.id);
-        }
+      if (appliedOffer) {
+        await storage.createOfferRedemption({
+          offerId: appliedOffer.id,
+          userId,
+          orderId: order.id,
+          discountAmount: discountAmount.toString(),
+        });
+        await storage.incrementOfferUsage(appliedOffer.id);
       }
 
       // Clear cart


### PR DESCRIPTION
## Summary
- persist the applied cart offer code in the React Query cache so it survives navigation
- include the saved coupon identifier when creating orders from checkout and clear it after purchase
- update the order creation route to accept the passed offer code, reuse it for discount calculations, and record the offer id once

## Testing
- npm run check *(fails: existing type errors in offer-table.tsx and storage.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d0466dd778832aaac9128387cbf3e7