### PR TITLE
Refine shipping rule query-based management

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -4,7 +4,16 @@ import rateLimit from "express-rate-limit";
 import { storage } from "./storage";
 import { otpService } from "./otp-service";
 import session from "express-session";
-import { insertProductSchema, insertOfferSchema, insertUserAddressSchema, insertUserSchema, insertShippingRuleSchema } from "@shared/schema";
+import {
+  insertProductSchema,
+  insertOfferSchema,
+  insertUserAddressSchema,
+  insertUserSchema,
+  insertShippingRuleSchema,
+  productQueryConditionsSchema,
+  locationQueryConditionsSchema,
+} from "@shared/schema";
+import type { InsertShippingRule } from "@shared/schema";
 import { z } from "zod";
 
 const sessionConfig = session({
@@ -1013,96 +1022,84 @@ order.deliveryAddress ? `${order.deliveryAddress.address}, ${order.deliveryAddre
     try {
       const idSchema = z.string().uuid();
       const id = idSchema.parse(req.params.id);
-      
-      // Check if request body is empty or all values are undefined
-      const bodyKeys = Object.keys(req.body).filter(key => req.body[key] !== undefined);
-      if (bodyKeys.length === 0) {
+
+      const supportedRuleTypeSchema = z.enum(["product_query_based", "location_query_based"]);
+      const bodySchema = z.object({
+        name: z.string().min(1).max(255).optional(),
+        description: z.string().max(2000).optional(),
+        shippingCharge: z.coerce.string().optional(),
+        isEnabled: z.boolean().optional(),
+        priority: z.number().int().min(0).max(1000000).optional(),
+        type: supportedRuleTypeSchema.optional(),
+        conditions: z.unknown().optional(),
+      }).strict();
+
+      const parsedBody = bodySchema.parse(req.body ?? {});
+
+      if (Object.keys(parsedBody).length === 0) {
         return res.status(400).json({ error: "No updates provided" });
       }
-      
-      // Fetch existing rule to determine effective type
+
       const existingRule = await storage.getShippingRule(id);
       if (!existingRule) {
         return res.status(404).json({ error: "Shipping rule not found" });
       }
-      
-      // For update, we allow partial updates but still validate structure when provided
-      const validatedUpdates: any = {};
-      if (req.body.name) validatedUpdates.name = z.string().min(1).max(255).parse(req.body.name);
-      if (req.body.description !== undefined) validatedUpdates.description = z.string().max(2000).optional().parse(req.body.description);
-      if (req.body.shippingCharge !== undefined) validatedUpdates.shippingCharge = z.coerce.string().parse(req.body.shippingCharge);
-      if (req.body.isEnabled !== undefined) validatedUpdates.isEnabled = z.boolean().parse(req.body.isEnabled);
-      if (req.body.priority !== undefined) validatedUpdates.priority = z.number().int().min(0).max(1000000).parse(req.body.priority);
-      if (req.body.type) validatedUpdates.type = z.enum(["product_based", "location_value_based", "product_query_based", "location_query_based"]).parse(req.body.type);
-      
-      // Determine effective type (updated type or existing type)
-      const effectiveType = validatedUpdates.type || existingRule.type;
-      
-      // Validate conditions if provided
-      if (req.body.conditions) {
-        // Create a schema for validating conditions based on effective type
-        const productBasedConditionsSchema = z.object({
-          productNames: z.array(z.string().min(1)).optional(),
-          categories: z.array(z.string().min(1)).optional(),
-          classifications: z.array(z.string().min(1)).optional(),
-        }).refine(
-          (data) => data.productNames?.length || data.categories?.length || data.classifications?.length,
-          { message: "At least one condition is required for product-based rules" }
-        );
-        
-        const locationValueBasedConditionsSchema = z.object({
-          pincodes: z.array(z.string().regex(/^\d{6}$/, "PIN code must be 6 digits")).optional(),
-          pincodeRanges: z.array(z.object({
-            start: z.string().regex(/^\d{6}$/, "Start PIN code must be 6 digits"),
-            end: z.string().regex(/^\d{6}$/, "End PIN code must be 6 digits")
-          })).optional(),
-          minOrderValue: z.coerce.number().min(0).optional(),
-          maxOrderValue: z.coerce.number().min(0).optional(),
-        }).refine(
-          (data) => data.pincodes?.length || data.pincodeRanges?.length || 
-                   data.minOrderValue !== undefined || data.maxOrderValue !== undefined,
-          { message: "At least one condition is required for location/value-based rules" }
-        );
-        
-        // Import query schemas from shared schema
-        const productQueryConditionsSchema = z.object({
-          rules: z.array(z.object({
-            field: z.enum(["productName", "category", "classification"]),
-            operator: z.enum(["IN", "NOT_IN", "BETWEEN", "NOT_BETWEEN", "EQUALS", "NOT_EQUALS", "GREATER_THAN", "LESS_THAN", "STARTS_WITH", "ENDS_WITH", "CONTAINS"]),
-            values: z.array(z.string()).min(1)
-          })).min(1),
-          logicalOperator: z.enum(["AND", "OR"]).default("AND")
+
+      const typeResult = supportedRuleTypeSchema.safeParse(parsedBody.type ?? existingRule.type);
+      if (!typeResult.success) {
+        return res.status(422).json({
+          error: "Unsupported shipping rule type. Please migrate this rule to a query-based rule.",
         });
-        
-        const locationQueryConditionsSchema = z.object({
-          rules: z.array(z.object({
-            field: z.enum(["pincode", "orderValue"]),
-            operator: z.enum(["IN", "NOT_IN", "BETWEEN", "NOT_BETWEEN", "EQUALS", "NOT_EQUALS", "GREATER_THAN", "LESS_THAN", "STARTS_WITH", "ENDS_WITH", "CONTAINS"]),
-            values: z.array(z.string()).min(1)
-          })).min(1),
-          logicalOperator: z.enum(["AND", "OR"]).default("AND")
-        });
-        
-        if (effectiveType === "product_based") {
-          validatedUpdates.conditions = productBasedConditionsSchema.parse(req.body.conditions);
-        } else if (effectiveType === "location_value_based") {
-          validatedUpdates.conditions = locationValueBasedConditionsSchema.parse(req.body.conditions);
-        } else if (effectiveType === "product_query_based") {
-          validatedUpdates.conditions = productQueryConditionsSchema.parse(req.body.conditions);
-        } else if (effectiveType === "location_query_based") {
-          validatedUpdates.conditions = locationQueryConditionsSchema.parse(req.body.conditions);
-        } else {
-          return res.status(422).json({ error: "Invalid rule type for conditions validation" });
-        }
       }
-      
+      const effectiveType = typeResult.data;
+
+      const validatedUpdates: Partial<InsertShippingRule> = {};
+
+      if (parsedBody.name !== undefined) validatedUpdates.name = parsedBody.name;
+      if (parsedBody.description !== undefined) validatedUpdates.description = parsedBody.description;
+      if (parsedBody.shippingCharge !== undefined) validatedUpdates.shippingCharge = parsedBody.shippingCharge;
+      if (parsedBody.isEnabled !== undefined) validatedUpdates.isEnabled = parsedBody.isEnabled;
+      if (parsedBody.priority !== undefined) validatedUpdates.priority = parsedBody.priority;
+      if (parsedBody.type !== undefined) validatedUpdates.type = parsedBody.type;
+
+      if (parsedBody.conditions !== undefined) {
+        const conditionsSchema = effectiveType === "product_query_based"
+          ? productQueryConditionsSchema
+          : locationQueryConditionsSchema;
+        validatedUpdates.conditions = conditionsSchema.parse(parsedBody.conditions);
+      } else if (parsedBody.type !== undefined) {
+        const conditionsSchema = effectiveType === "product_query_based"
+          ? productQueryConditionsSchema
+          : locationQueryConditionsSchema;
+        const parsedExistingConditions = conditionsSchema.safeParse(existingRule.conditions);
+        if (!parsedExistingConditions.success) {
+          return res.status(422).json({
+            error: "Conditions must be provided when changing rule type",
+            details: parsedExistingConditions.error.errors,
+          });
+        }
+        validatedUpdates.conditions = parsedExistingConditions.data;
+      }
+
+      const finalRuleForValidation = {
+        type: (validatedUpdates.type ?? effectiveType) as "product_query_based" | "location_query_based",
+        conditions: validatedUpdates.conditions ?? existingRule.conditions,
+        name: validatedUpdates.name ?? existingRule.name,
+        description: (validatedUpdates.description ?? existingRule.description ?? undefined) as string | undefined,
+        shippingCharge: String(validatedUpdates.shippingCharge ?? existingRule.shippingCharge),
+        isEnabled: validatedUpdates.isEnabled ?? (existingRule.isEnabled ?? true),
+        priority: validatedUpdates.priority ?? (existingRule.priority ?? 0),
+      };
+
+      insertShippingRuleSchema.parse(finalRuleForValidation);
+
       const rule = await storage.updateShippingRule(id, validatedUpdates);
       res.json(rule);
     } catch (error: any) {
       if (error instanceof z.ZodError) {
-        return res.status(422).json({ 
-          error: "Validation failed", 
-          details: error.errors 
+        return res.status(422).json({
+          error: "Validation failed",
+          details: error.errors
         });
       }
       if (error?.message?.includes("not found")) {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -355,12 +355,12 @@ const locationQueryRuleSchema = baseQueryRuleSchema.extend({
 }, { message: "Invalid number of values for the selected operator" });
 
 // Query conditions with logical operators
-const productQueryConditionsSchema = z.object({
+export const productQueryConditionsSchema = z.object({
   rules: z.array(productQueryRuleSchema).min(1, "At least one rule is required"),
   logicalOperator: z.enum(["AND", "OR"]).default("AND"),
 });
 
-const locationQueryConditionsSchema = z.object({
+export const locationQueryConditionsSchema = z.object({
   rules: z.array(locationQueryRuleSchema).min(1, "At least one rule is required"),
   logicalOperator: z.enum(["AND", "OR"]).default("AND"),
 });


### PR DESCRIPTION
## Summary
- restrict the admin shipping rule form to the two query-based types with defaulted QueryBuilder conditions
- remove the legacy condition editors in favor of QueryBuilder and sanitize existing rules when editing
- align PATCH validation with the query-based insertShippingRuleSchema and export the shared query condition schemas for reuse

## Testing
- npm run check *(fails: pre-existing type errors in client/src/components/admin/offer-table.tsx, client/src/pages/cart.tsx, server/storage.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d06758b304832a9465aeb299911983