### PR TITLE
Standardize admin settings update endpoint

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1471,34 +1471,6 @@ order.deliveryAddress ? `${order.deliveryAddress.address}, ${order.deliveryAddre
     }
   });
 
-  // App settings endpoints
-  app.get('/api/admin/settings', requireAdmin, async (req, res) => {
-    try {
-      const settings = await storage.getAppSettings();
-      res.json(settings);
-    } catch (error) {
-      console.error('Error fetching app settings:', error);
-      res.status(500).json({ error: 'Failed to fetch app settings' });
-    }
-  });
-
-  app.put('/api/admin/settings/:key', requireAdmin, async (req, res) => {
-    try {
-      const { key } = req.params;
-      const { value } = req.body;
-
-      if (!value) {
-        return res.status(400).json({ error: 'Value is required' });
-      }
-
-      const setting = await storage.updateAppSetting(key, value, 'admin');
-      res.json(setting);
-    } catch (error) {
-      console.error('Error updating app setting:', error);
-      res.status(500).json({ error: 'Failed to update app setting' });
-    }
-  });
-
   // Initialize default app settings
   async function initializeDefaultSettings() {
     try {


### PR DESCRIPTION
## Summary
- remove the duplicate `/api/admin/settings` GET/PUT handlers so the earlier GET/PATCH pair is the single source of truth

## Testing
- npm run check *(fails: existing TypeScript errors in unrelated admin offer table, cart page, and storage code)*

------
https://chatgpt.com/codex/tasks/task_e_68d0675943e8832aa729730622ad4609