### PR TITLE
Add missing useQuery import to cart page

### DIFF
--- a/client/src/pages/cart.tsx
+++ b/client/src/pages/cart.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient, useQuery } from "@tanstack/react-query";
 import { useCart } from "@/hooks/use-cart";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";


### PR DESCRIPTION
## Summary
- add the missing useQuery import to the cart page so the hook is available when the component runs

## Testing
- npm run check *(fails: existing type errors in client/src/components/admin/offer-table.tsx and server/storage.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c37da830832ab35344a632927bda