### PR TITLE
Add Docker build assets and deployment documentation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+node_modules
+dist
+.git
+.gitignore
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.vscode
+.idea
+coverage
+tmp
+*.local
+.env*
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# syntax=docker/dockerfile:1
+
+FROM node:20-bookworm AS builder
+WORKDIR /app
+
+ENV NODE_ENV=development
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+
+RUN npm run build
+
+FROM node:20-bookworm-slim AS production
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PORT=5000
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+COPY --from=builder /app/dist ./dist
+
+EXPOSE 5000
+
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# rest-express
+
+## Container Deployment Notes
+
+This repository ships with a multi-stage Dockerfile that installs dependencies, runs the build, and starts the compiled server via `npm start`. The container listens on the port provided by the `PORT` environment variable (default `5000`).
+
+### Building and Running Locally
+
+```bash
+docker build -t rest-express .
+docker run --rm -p 5000:5000 \
+  -e DATABASE_URL="postgres://user:pass@host:5432/db" \
+  -e SESSION_SECRET="replace-me" \
+  -e PUBLIC_OBJECT_SEARCH_PATHS="/bucket/public" \
+  -e PRIVATE_OBJECT_DIR="/bucket/private" \
+  rest-express
+```
+
+### Required Environment Variables
+
+These variables must be provided by any container platform so the application can start successfully:
+
+- `DATABASE_URL` – PostgreSQL connection string used by the Neon/Drizzle database client.
+- `SESSION_SECRET` – secret key for Express session cookies.
+- Storage configuration:
+  - `PUBLIC_OBJECT_SEARCH_PATHS` – comma-separated GCS bucket paths that host publicly served assets.
+  - `PRIVATE_OBJECT_DIR` – bucket path prefix used for private object uploads and signed URLs.
+- (Optional) `TWOFACTOR_API_KEY` – required if integrating with the external 2Factor OTP provider.
+
+Set `PORT` if your platform requires a specific port binding; otherwise the container defaults to `5000`.


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile that builds the project and starts it with npm start
- ignore development artifacts from Docker contexts via .dockerignore
- document container deployment requirements and env vars in the README

## Testing
- `npm run check`
- `npm run build`
- `docker --version` *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c90c8a10832aa534df760b1f0f5f