### PR TITLE
Harden payment schema constraints and secret validation

### DIFF
--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -62,9 +62,12 @@ Both refactors improved maintainability but did not change **endpoint URLs** or 
    - `/api/analytics` in `server/routes/analytics.ts`.  
    - Returned datasets and dashboards unchanged.
 
-5. **Settings**  
-   - `/api/admin/settings` in `server/routes/admin.ts`, backed by `settingsRepository`.  
+5. **Settings**
+   - `/api/admin/settings` in `server/routes/admin.ts`, backed by `settingsRepository`.
    - Setting keys/values and auditing semantics preserved.
+6. **Payment Providers**
+   - Enabling a gateway now requires matching Replit secrets to be present.
+   - Missing secrets cause an explicit configuration error instead of silently proceeding, ensuring admins fix misconfigurations before go-live.
 
 ---
 
@@ -93,3 +96,4 @@ Both refactors improved maintainability but did not change **endpoint URLs** or 
 ⚠️ **Next Step:** If future changes modify request/response contracts or flow logic, this document should be updated to capture:
 - Dependencies between repositories and routes.
 - Any changed behavior for buyers, admins, or influencers.
+- Payment enablement prerequisites for each environment.

--- a/migrations/0001_payment_uniques.sql
+++ b/migrations/0001_payment_uniques.sql
@@ -1,0 +1,14 @@
+-- Ensure unique indexes managed by Drizzle for payment infrastructure
+CREATE UNIQUE INDEX IF NOT EXISTS payments_provider_payment_unique
+  ON payments (provider, provider_payment_id)
+  WHERE provider_payment_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS refunds_provider_refund_unique
+  ON refunds (provider, provider_refund_id)
+  WHERE provider_refund_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS webhook_inbox_provider_dedupe_unique
+  ON webhook_inbox (provider, dedupe_key);
+
+CREATE UNIQUE INDEX IF NOT EXISTS payment_provider_config_tenant_provider_env_unique
+  ON payment_provider_config (tenant_id, provider, environment);

--- a/server/services/config-resolver.ts
+++ b/server/services/config-resolver.ts
@@ -85,27 +85,27 @@ export class ConfigResolver {
       provider,
       environment,
       enabled: dbConfig?.isEnabled ?? false,
-      
+
       // Database fields
-      merchantId: dbConfig?.merchantId,
-      keyId: dbConfig?.keyId,
-      accessCode: dbConfig?.accessCode,
-      appId: dbConfig?.appId,
-      publishableKey: dbConfig?.publishableKey,
-      saltIndex: dbConfig?.saltIndex,
-      accountId: dbConfig?.accountId,
-      
+      merchantId: dbConfig?.merchantId ?? undefined,
+      keyId: dbConfig?.keyId ?? undefined,
+      accessCode: dbConfig?.accessCode ?? undefined,
+      appId: dbConfig?.appId ?? undefined,
+      publishableKey: dbConfig?.publishableKey ?? undefined,
+      saltIndex: dbConfig?.saltIndex ?? undefined,
+      accountId: dbConfig?.accountId ?? undefined,
+
       // URLs
-      successUrl: dbConfig?.successUrl,
-      failureUrl: dbConfig?.failureUrl,
-      webhookUrl: dbConfig?.webhookUrl,
-      
+      successUrl: dbConfig?.successUrl ?? undefined,
+      failureUrl: dbConfig?.failureUrl ?? undefined,
+      webhookUrl: dbConfig?.webhookUrl ?? undefined,
+
       // Secrets
       secrets,
-      
+
       // Capabilities and metadata
-      capabilities: dbConfig?.capabilities ?? {},
-      metadata: dbConfig?.metadata ?? {},
+      capabilities: (dbConfig?.capabilities as Record<string, boolean> | null) ?? {},
+      metadata: (dbConfig?.metadata as Record<string, any> | null) ?? {},
       
       // Validation
       isValid: validation.isValid && (dbConfig?.isEnabled ?? false),


### PR DESCRIPTION
## Summary
- replace raw SQL unique constraints in the payments schema with drizzle-managed indexes and add an accompanying SQL migration
- hard-fail secret resolution when required PAYAPP_* environment variables are absent and normalise optional config values
- document the updated payment-provider enablement behaviour for admins

## Testing
- npm run check *(fails: existing TypeScript errors in admin UI and legacy payment repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68d50d50354c832abb0eda4b254135fc