### PR TITLE
Add missing payment adapters and harden webhook routing

### DIFF
--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -68,6 +68,7 @@ Both refactors improved maintainability but did not change **endpoint URLs** or 
 6. **Payment Providers**
    - Enabling a gateway now requires matching Replit secrets to be present.
    - Missing secrets cause an explicit configuration error instead of silently proceeding, ensuring admins fix misconfigurations before go-live.
+   - Webhook ingestion now auto-detects the correct provider across all enabled configs per tenant and deduplicates payloads with tenant-aware hashes, preventing cross-tenant collisions.
 
 ---
 

--- a/server/adapters/billdesk-adapter.ts
+++ b/server/adapters/billdesk-adapter.ts
@@ -1,0 +1,441 @@
+import crypto from "crypto";
+import type {
+  PaymentsAdapter,
+  CreatePaymentParams,
+  PaymentResult,
+  VerifyPaymentParams,
+  CapturePaymentParams,
+  CreateRefundParams,
+  RefundResult,
+  WebhookVerifyParams,
+  WebhookVerifyResult,
+  HealthCheckParams,
+  HealthCheckResult,
+  PaymentMethod,
+  Currency,
+  PaymentStatus,
+  RefundStatus,
+} from "../../shared/payment-types";
+import type { PaymentProvider, Environment } from "../../shared/payment-providers";
+import type { ResolvedConfig } from "../services/config-resolver";
+import { PaymentError, RefundError, WebhookError } from "../../shared/payment-types";
+
+interface BillDeskOrderResponse {
+  order_id: string;
+  order_amount: number;
+  order_currency: string;
+  order_status: string;
+  payment_amount?: number;
+  payment_id?: string;
+  payment_mode?: string;
+  payment_time?: string;
+}
+
+interface BillDeskRefundResponse {
+  refund_id: string;
+  order_id: string;
+  refund_amount: number;
+  refund_status: string;
+  initiated_at?: string;
+}
+
+export class BillDeskAdapter implements PaymentsAdapter {
+  public readonly provider: PaymentProvider = "billdesk";
+  public readonly environment: Environment;
+
+  private readonly merchantId: string;
+  private readonly checksumKey: string;
+  private readonly baseUrl: string;
+
+  constructor(private readonly config: ResolvedConfig) {
+    this.environment = config.environment;
+
+    this.merchantId = config.merchantId || "";
+    this.checksumKey = config.secrets.checksumKey || "";
+
+    this.baseUrl = this.environment === "live"
+      ? "https://api.billdesk.com/payments"
+      : "https://pguat.billdesk.io/payments";
+
+    if (!this.merchantId || !this.checksumKey) {
+      throw new PaymentError(
+        "Missing BillDesk credentials",
+        "MISSING_CREDENTIALS",
+        "billdesk"
+      );
+    }
+  }
+
+  public async createPayment(params: CreatePaymentParams): Promise<PaymentResult> {
+    try {
+      const payload = {
+        merchantId: this.merchantId,
+        orderId: params.orderId,
+        amount: params.orderAmount / 100,
+        currency: params.currency,
+        returnUrl: params.successUrl,
+        notifyUrl: params.providerOptions?.notifyUrl,
+        customer: {
+          id: params.customer.id,
+          email: params.customer.email,
+          mobile: params.customer.phone,
+          name: params.customer.name,
+        },
+        metadata: params.metadata,
+      };
+
+      const checksum = this.generateChecksum(payload);
+
+      const result: PaymentResult = {
+        paymentId: crypto.randomUUID(),
+        providerPaymentId: params.orderId,
+        providerOrderId: params.orderId,
+        status: "initiated",
+        amount: params.orderAmount,
+        currency: params.currency,
+        provider: "billdesk",
+        environment: this.environment,
+        redirectUrl: `${this.baseUrl}/v1.2/pg/orders/${encodeURIComponent(params.orderId)}`,
+        providerData: {
+          payload,
+          checksum,
+        },
+        createdAt: new Date(),
+      };
+
+      return result;
+    } catch (error) {
+      console.error("BillDesk payment creation failed:", error);
+      throw new PaymentError(
+        `BillDesk payment creation failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        "PAYMENT_CREATION_FAILED",
+        "billdesk",
+        error
+      );
+    }
+  }
+
+  public async verifyPayment(params: VerifyPaymentParams): Promise<PaymentResult> {
+    try {
+      const orderId = params.providerPaymentId || params.paymentId;
+
+      if (!orderId) {
+        throw new PaymentError("Missing BillDesk order identifier", "MISSING_VERIFICATION_DATA", "billdesk");
+      }
+
+      const response = await this.makeApiCall<BillDeskOrderResponse>(
+        `/v1.2/pg/orders/${orderId}`,
+        "GET"
+      );
+
+      const result: PaymentResult = {
+        paymentId: params.paymentId,
+        providerPaymentId: response.payment_id || orderId,
+        providerOrderId: response.order_id,
+        status: this.mapPaymentStatus(response.order_status),
+        amount: Math.round((response.payment_amount || response.order_amount) * 100),
+        currency: response.order_currency as Currency,
+        provider: "billdesk",
+        environment: this.environment,
+        method: response.payment_mode ? { type: this.detectMethod(response.payment_mode) } : undefined,
+        providerData: response,
+        createdAt: response.payment_time ? new Date(response.payment_time) : new Date(),
+        updatedAt: new Date(),
+      };
+
+      return result;
+    } catch (error) {
+      console.error("BillDesk payment verification failed:", error);
+      throw new PaymentError(
+        `Payment verification failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        "PAYMENT_VERIFICATION_FAILED",
+        "billdesk",
+        error
+      );
+    }
+  }
+
+  public async capturePayment(params: CapturePaymentParams): Promise<PaymentResult> {
+    try {
+      // BillDesk processes payments synchronously; return verification result.
+      return this.verifyPayment({
+        paymentId: params.paymentId,
+        providerPaymentId: params.providerPaymentId,
+      });
+    } catch (error) {
+      console.error("BillDesk capture failed:", error);
+      throw new PaymentError(
+        `Payment capture failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        "PAYMENT_CAPTURE_FAILED",
+        "billdesk",
+        error
+      );
+    }
+  }
+
+  public async createRefund(params: CreateRefundParams): Promise<RefundResult> {
+    try {
+      const orderId = params.providerPaymentId;
+
+      if (!orderId) {
+        throw new RefundError("Missing BillDesk order identifier", "MISSING_PROVIDER_PAYMENT_ID", "billdesk");
+      }
+
+      const request = {
+        refund_amount: params.amount ? params.amount / 100 : undefined,
+        refund_ref_no: `REF_${Date.now()}`,
+        reason: params.reason,
+      };
+
+      const response = await this.makeApiCall<BillDeskRefundResponse>(
+        `/v1.2/pg/orders/${orderId}/refunds`,
+        "POST",
+        request
+      );
+
+      const result: RefundResult = {
+        refundId: response.refund_id,
+        paymentId: params.paymentId,
+        providerRefundId: response.refund_id,
+        amount: Math.round(response.refund_amount * 100),
+        status: this.mapRefundStatus(response.refund_status),
+        provider: "billdesk",
+        environment: this.environment,
+        reason: params.reason,
+        notes: params.notes,
+        providerData: response,
+        createdAt: response.initiated_at ? new Date(response.initiated_at) : new Date(),
+      };
+
+      return result;
+    } catch (error) {
+      console.error("BillDesk refund creation failed:", error);
+      throw new RefundError(
+        `Refund creation failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        "REFUND_CREATION_FAILED",
+        "billdesk",
+        error
+      );
+    }
+  }
+
+  public async getRefundStatus(refundId: string): Promise<RefundResult> {
+    try {
+      const response = await this.makeApiCall<BillDeskRefundResponse>(
+        `/v1.2/pg/refunds/${refundId}`,
+        "GET"
+      );
+
+      const result: RefundResult = {
+        refundId: response.refund_id || refundId,
+        paymentId: response.order_id || "",
+        providerRefundId: response.refund_id || refundId,
+        amount: Math.round(response.refund_amount * 100),
+        status: this.mapRefundStatus(response.refund_status),
+        provider: "billdesk",
+        environment: this.environment,
+        providerData: response,
+        createdAt: response.initiated_at ? new Date(response.initiated_at) : new Date(),
+        updatedAt: new Date(),
+      };
+
+      return result;
+    } catch (error) {
+      console.error("BillDesk refund status check failed:", error);
+      throw new RefundError(
+        `Refund status check failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        "REFUND_STATUS_CHECK_FAILED",
+        "billdesk",
+        error
+      );
+    }
+  }
+
+  public async verifyWebhook(params: WebhookVerifyParams): Promise<WebhookVerifyResult> {
+    try {
+      const signature = params.headers["bd-signature"] || params.signature;
+
+      if (!signature) {
+        return { verified: false, error: { code: "MISSING_SIGNATURE", message: "Missing BillDesk signature" } };
+      }
+
+      const expected = this.generateChecksum(params.body.toString());
+
+      if (signature !== expected) {
+        return { verified: false, error: { code: "INVALID_SIGNATURE", message: "Invalid webhook signature" } };
+      }
+
+      const payload = JSON.parse(params.body.toString());
+
+      return {
+        verified: true,
+        event: {
+          type: payload.event || "payment.update",
+          paymentId: payload.data?.payment_id || payload.data?.order_id,
+          refundId: payload.data?.refund_id,
+          status: payload.data?.status,
+          data: payload.data || payload,
+        },
+        providerData: payload,
+      };
+    } catch (error) {
+      console.error("BillDesk webhook verification failed:", error);
+      return {
+        verified: false,
+        error: {
+          code: "WEBHOOK_VERIFICATION_FAILED",
+          message: error instanceof Error ? error.message : "Unknown error",
+        },
+      };
+    }
+  }
+
+  public async healthCheck(_params?: HealthCheckParams): Promise<HealthCheckResult> {
+    const start = Date.now();
+
+    try {
+      await this.makeApiCall("/v1.2/pg/orders?limit=1", "GET");
+
+      const responseTime = Date.now() - start;
+
+      return {
+        provider: "billdesk",
+        environment: this.environment,
+        healthy: true,
+        responseTime,
+        tests: {
+          connectivity: true,
+          authentication: true,
+          apiAccess: true,
+        },
+        timestamp: new Date(),
+      };
+    } catch (error) {
+      return {
+        provider: "billdesk",
+        environment: this.environment,
+        healthy: false,
+        responseTime: Date.now() - start,
+        tests: {
+          connectivity: false,
+          authentication: false,
+          apiAccess: false,
+        },
+        error: {
+          code: "HEALTH_CHECK_FAILED",
+          message: error instanceof Error ? error.message : "Unknown error",
+        },
+        timestamp: new Date(),
+      };
+    }
+  }
+
+  public getSupportedMethods(): PaymentMethod[] {
+    return ["card", "upi", "netbanking"];
+  }
+
+  public getSupportedCurrencies(): Currency[] {
+    return ["INR"];
+  }
+
+  public async validateConfig(): Promise<{ valid: boolean; errors: string[] }> {
+    const errors: string[] = [];
+
+    if (!this.merchantId) {
+      errors.push("Missing BillDesk Merchant ID");
+    }
+
+    if (!this.checksumKey) {
+      errors.push("Missing BillDesk Checksum Key");
+    }
+
+    return { valid: errors.length === 0, errors };
+  }
+
+  private async makeApiCall<T>(endpoint: string, method: "GET" | "POST", data?: any): Promise<T> {
+    const url = `${this.baseUrl}${endpoint}`;
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      "User-Agent": "PaymentApp/1.0",
+      "merchantId": this.merchantId,
+    };
+
+    const response = await fetch(url, {
+      method,
+      headers,
+      body: data ? JSON.stringify(data) : undefined,
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`BillDesk API error: ${response.status} ${text}`);
+    }
+
+    if (response.status === 204) {
+      return {} as T;
+    }
+
+    return response.json() as Promise<T>;
+  }
+
+  private generateChecksum(payload: any): string {
+    const data = typeof payload === "string" ? payload : JSON.stringify(payload);
+    return crypto.createHmac("sha256", this.checksumKey).update(data, "utf8").digest("base64");
+  }
+
+  private mapPaymentStatus(status: string): PaymentStatus {
+    switch ((status || "").toUpperCase()) {
+      case "INITIATED":
+        return "initiated";
+      case "PENDING":
+      case "IN_PROGRESS":
+        return "processing";
+      case "SUCCESS":
+      case "PAID":
+      case "COMPLETED":
+        return "captured";
+      case "FAILED":
+      case "DECLINED":
+      case "CANCELLED":
+        return "failed";
+      case "REFUNDED":
+        return "refunded";
+      default:
+        return "failed";
+    }
+  }
+
+  private mapRefundStatus(status: string): RefundStatus {
+    switch ((status || "").toUpperCase()) {
+      case "SUCCESS":
+      case "COMPLETED":
+        return "completed";
+      case "PENDING":
+      case "IN_PROGRESS":
+        return "processing";
+      case "FAILED":
+      case "DECLINED":
+        return "failed";
+      case "CANCELLED":
+        return "cancelled";
+      default:
+        return "pending";
+    }
+  }
+
+  private detectMethod(method: string): PaymentMethod {
+    switch ((method || "").toLowerCase()) {
+      case "upi":
+        return "upi";
+      case "netbanking":
+        return "netbanking";
+      case "card":
+      case "credit_card":
+      case "debit_card":
+        return "card";
+      default:
+        return "card";
+    }
+  }
+}

--- a/server/adapters/cashfree-adapter.ts
+++ b/server/adapters/cashfree-adapter.ts
@@ -1,0 +1,476 @@
+import crypto from "crypto";
+import type {
+  PaymentsAdapter,
+  CreatePaymentParams,
+  PaymentResult,
+  VerifyPaymentParams,
+  CapturePaymentParams,
+  CreateRefundParams,
+  RefundResult,
+  WebhookVerifyParams,
+  WebhookVerifyResult,
+  HealthCheckParams,
+  HealthCheckResult,
+  PaymentMethod,
+  Currency,
+  PaymentStatus,
+  RefundStatus,
+} from "../../shared/payment-types";
+import type { PaymentProvider, Environment } from "../../shared/payment-providers";
+import type { ResolvedConfig } from "../services/config-resolver";
+import { PaymentError, RefundError, WebhookError } from "../../shared/payment-types";
+
+interface CashfreeOrderResponse {
+  order_id: string;
+  order_amount: number;
+  order_currency: string;
+  order_status: string;
+  payment_session_id?: string;
+  cf_payment_id?: string;
+  created_at?: string;
+  customer_details?: {
+    customer_id?: string;
+    customer_email?: string;
+    customer_phone?: string;
+  };
+  payment_details?: Array<{
+    cf_payment_id: string;
+    payment_method: string;
+    payment_status: string;
+    payment_amount: number;
+    bank_reference?: string;
+  }>;
+}
+
+interface CashfreeRefundResponse {
+  refund_id: string;
+  cf_payment_id?: string;
+  order_id?: string;
+  refund_amount: number;
+  refund_status: string;
+  refund_note?: string;
+  initiated_at?: string;
+}
+
+export class CashfreeAdapter implements PaymentsAdapter {
+  public readonly provider: PaymentProvider = "cashfree";
+  public readonly environment: Environment;
+
+  private readonly appId: string;
+  private readonly secretKey: string;
+  private readonly webhookSecret?: string;
+  private readonly baseUrl: string;
+
+  constructor(private readonly config: ResolvedConfig) {
+    this.environment = config.environment;
+
+    this.appId = config.appId || config.keyId || "";
+    this.secretKey = config.secrets.keySecret || "";
+    this.webhookSecret = config.secrets.webhookSecret;
+
+    this.baseUrl = this.environment === "live"
+      ? "https://api.cashfree.com/pg"
+      : "https://sandbox.cashfree.com/pg";
+
+    if (!this.appId || !this.secretKey) {
+      throw new PaymentError(
+        "Missing Cashfree credentials",
+        "MISSING_CREDENTIALS",
+        "cashfree"
+      );
+    }
+  }
+
+  public async createPayment(params: CreatePaymentParams): Promise<PaymentResult> {
+    try {
+      const request = {
+        order_id: params.orderId,
+        order_amount: params.orderAmount / 100,
+        order_currency: params.currency,
+        customer_details: {
+          customer_id: params.customer.id || params.customer.email || params.customer.phone || `cust_${Date.now()}`,
+          customer_email: params.customer.email,
+          customer_phone: params.customer.phone,
+        },
+        order_meta: {
+          return_url: params.successUrl,
+          notify_url: params.providerOptions?.notifyUrl,
+        },
+      };
+
+      const response = await this.makeApiCall<CashfreeOrderResponse>("/orders", "POST", request);
+
+      const result: PaymentResult = {
+        paymentId: crypto.randomUUID(),
+        providerPaymentId: response.order_id,
+        providerOrderId: response.order_id,
+        status: this.mapPaymentStatus(response.order_status),
+        amount: Math.round(response.order_amount * 100),
+        currency: response.order_currency as Currency,
+        provider: "cashfree",
+        environment: this.environment,
+        providerData: {
+          paymentSessionId: response.payment_session_id,
+          cfPaymentId: response.cf_payment_id,
+        },
+        createdAt: response.created_at ? new Date(response.created_at) : new Date(),
+      };
+
+      return result;
+    } catch (error) {
+      console.error("Cashfree payment creation failed:", error);
+      throw new PaymentError(
+        `Cashfree payment creation failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        "PAYMENT_CREATION_FAILED",
+        "cashfree",
+        error
+      );
+    }
+  }
+
+  public async verifyPayment(params: VerifyPaymentParams): Promise<PaymentResult> {
+    try {
+      const providerOrderId = params.providerPaymentId || params.paymentId;
+
+      if (!providerOrderId) {
+        throw new PaymentError("Missing Cashfree order identifier", "MISSING_VERIFICATION_DATA", "cashfree");
+      }
+
+      const response = await this.makeApiCall<CashfreeOrderResponse>(
+        `/orders/${providerOrderId}`,
+        "GET"
+      );
+
+      const payment = response.payment_details?.[0];
+
+      const result: PaymentResult = {
+        paymentId: params.paymentId,
+        providerPaymentId: payment?.cf_payment_id || response.order_id,
+        providerOrderId: response.order_id,
+        status: this.mapPaymentStatus(payment?.payment_status || response.order_status),
+        amount: Math.round((payment?.payment_amount || response.order_amount) * 100),
+        currency: response.order_currency as Currency,
+        provider: "cashfree",
+        environment: this.environment,
+        method: payment?.payment_method
+          ? { type: this.detectMethod(payment.payment_method) }
+          : undefined,
+        providerData: {
+          payment,
+          order: response,
+        },
+        createdAt: response.created_at ? new Date(response.created_at) : new Date(),
+        updatedAt: new Date(),
+      };
+
+      return result;
+    } catch (error) {
+      console.error("Cashfree payment verification failed:", error);
+      throw new PaymentError(
+        `Payment verification failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        "PAYMENT_VERIFICATION_FAILED",
+        "cashfree",
+        error
+      );
+    }
+  }
+
+  public async capturePayment(params: CapturePaymentParams): Promise<PaymentResult> {
+    try {
+      const providerOrderId = params.providerPaymentId || params.paymentId;
+
+      if (!providerOrderId) {
+        throw new PaymentError("Missing Cashfree order identifier", "MISSING_PROVIDER_PAYMENT_ID", "cashfree");
+      }
+
+      await this.makeApiCall(
+        `/orders/${providerOrderId}/capture`,
+        "POST",
+        params.amount ? { amount: params.amount / 100 } : undefined
+      );
+
+      return this.verifyPayment({
+        paymentId: params.paymentId,
+        providerPaymentId: providerOrderId,
+      });
+    } catch (error) {
+      console.error("Cashfree capture failed:", error);
+      throw new PaymentError(
+        `Payment capture failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        "PAYMENT_CAPTURE_FAILED",
+        "cashfree",
+        error
+      );
+    }
+  }
+
+  public async createRefund(params: CreateRefundParams): Promise<RefundResult> {
+    try {
+      const providerOrderId = params.providerPaymentId;
+
+      if (!providerOrderId) {
+        throw new RefundError("Missing Cashfree order identifier", "MISSING_PROVIDER_PAYMENT_ID", "cashfree");
+      }
+
+      const request = {
+        refund_amount: params.amount ? params.amount / 100 : undefined,
+        refund_note: params.reason,
+      };
+
+      const response = await this.makeApiCall<CashfreeRefundResponse>(
+        `/orders/${providerOrderId}/refunds`,
+        "POST",
+        request
+      );
+
+      const result: RefundResult = {
+        refundId: response.refund_id,
+        paymentId: params.paymentId,
+        providerRefundId: response.refund_id,
+        amount: Math.round(response.refund_amount * 100),
+        status: this.mapRefundStatus(response.refund_status),
+        provider: "cashfree",
+        environment: this.environment,
+        reason: params.reason,
+        notes: params.notes,
+        providerData: response,
+        createdAt: response.initiated_at ? new Date(response.initiated_at) : new Date(),
+      };
+
+      return result;
+    } catch (error) {
+      console.error("Cashfree refund creation failed:", error);
+      throw new RefundError(
+        `Refund creation failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        "REFUND_CREATION_FAILED",
+        "cashfree",
+        error
+      );
+    }
+  }
+
+  public async getRefundStatus(refundId: string): Promise<RefundResult> {
+    try {
+      const response = await this.makeApiCall<CashfreeRefundResponse>(
+        `/refunds/${refundId}`,
+        "GET"
+      );
+
+      const result: RefundResult = {
+        refundId: response.refund_id || refundId,
+        paymentId: response.order_id || "",
+        providerRefundId: response.refund_id || refundId,
+        amount: Math.round(response.refund_amount * 100),
+        status: this.mapRefundStatus(response.refund_status),
+        provider: "cashfree",
+        environment: this.environment,
+        providerData: response,
+        createdAt: response.initiated_at ? new Date(response.initiated_at) : new Date(),
+        updatedAt: new Date(),
+      };
+
+      return result;
+    } catch (error) {
+      console.error("Cashfree refund status check failed:", error);
+      throw new RefundError(
+        `Refund status check failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        "REFUND_STATUS_CHECK_FAILED",
+        "cashfree",
+        error
+      );
+    }
+  }
+
+  public async verifyWebhook(params: WebhookVerifyParams): Promise<WebhookVerifyResult> {
+    try {
+      if (!this.webhookSecret) {
+        throw new WebhookError("Webhook secret not configured", "WEBHOOK_SECRET_MISSING", "cashfree");
+      }
+
+      const signature = params.headers["x-webhook-signature"];
+      if (!signature) {
+        return { verified: false, error: { code: "MISSING_SIGNATURE", message: "Missing Cashfree signature" } };
+      }
+
+      const expected = crypto
+        .createHmac("sha256", this.webhookSecret)
+        .update(params.body.toString(), "utf8")
+        .digest("base64");
+
+      if (signature !== expected) {
+        return { verified: false, error: { code: "INVALID_SIGNATURE", message: "Invalid webhook signature" } };
+      }
+
+      const payload = JSON.parse(params.body.toString());
+      const eventType = payload.type || payload.event || "payment.update";
+
+      return {
+        verified: true,
+        event: {
+          type: eventType,
+          paymentId: payload.data?.cf_payment_id || payload.data?.order_id,
+          refundId: payload.data?.refund_id,
+          status: payload.data?.status,
+          data: payload.data || payload,
+        },
+        providerData: payload,
+      };
+    } catch (error) {
+      console.error("Cashfree webhook verification failed:", error);
+      return {
+        verified: false,
+        error: {
+          code: "WEBHOOK_VERIFICATION_FAILED",
+          message: error instanceof Error ? error.message : "Unknown error",
+        },
+      };
+    }
+  }
+
+  public async healthCheck(_params?: HealthCheckParams): Promise<HealthCheckResult> {
+    const start = Date.now();
+
+    try {
+      await this.makeApiCall("/orders?limit=1", "GET");
+
+      const responseTime = Date.now() - start;
+
+      return {
+        provider: "cashfree",
+        environment: this.environment,
+        healthy: true,
+        responseTime,
+        tests: {
+          connectivity: true,
+          authentication: true,
+          apiAccess: true,
+        },
+        timestamp: new Date(),
+      };
+    } catch (error) {
+      return {
+        provider: "cashfree",
+        environment: this.environment,
+        healthy: false,
+        responseTime: Date.now() - start,
+        tests: {
+          connectivity: false,
+          authentication: false,
+          apiAccess: false,
+        },
+        error: {
+          code: "HEALTH_CHECK_FAILED",
+          message: error instanceof Error ? error.message : "Unknown error",
+        },
+        timestamp: new Date(),
+      };
+    }
+  }
+
+  public getSupportedMethods(): PaymentMethod[] {
+    return ["card", "upi", "netbanking", "wallet"];
+  }
+
+  public getSupportedCurrencies(): Currency[] {
+    return ["INR"];
+  }
+
+  public async validateConfig(): Promise<{ valid: boolean; errors: string[] }> {
+    const errors: string[] = [];
+
+    if (!this.appId) {
+      errors.push("Missing Cashfree App ID");
+    }
+
+    if (!this.secretKey) {
+      errors.push("Missing Cashfree Secret Key");
+    }
+
+    return { valid: errors.length === 0, errors };
+  }
+
+  private async makeApiCall<T>(endpoint: string, method: "GET" | "POST" | "PUT" | "DELETE", data?: any): Promise<T> {
+    const url = `${this.baseUrl}${endpoint}`;
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      "x-client-id": this.appId,
+      "x-client-secret": this.secretKey,
+      "x-api-version": "2022-09-01",
+      "User-Agent": "PaymentApp/1.0",
+    };
+
+    const response = await fetch(url, {
+      method,
+      headers,
+      body: data ? JSON.stringify(data) : undefined,
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Cashfree API error: ${response.status} ${text}`);
+    }
+
+    if (response.status === 204) {
+      return {} as T;
+    }
+
+    return response.json() as Promise<T>;
+  }
+
+  private mapPaymentStatus(status?: string): PaymentStatus {
+    switch ((status || "").toUpperCase()) {
+      case "PAYMENT_PENDING":
+      case "PENDING":
+        return "processing";
+      case "AUTHORIZED":
+        return "authorized";
+      case "SUCCESS":
+      case "COMPLETED":
+      case "CAPTURED":
+        return "captured";
+      case "FAILED":
+      case "CANCELLED":
+        return "failed";
+      case "REFUNDED":
+        return "refunded";
+      default:
+        return "failed";
+    }
+  }
+
+  private mapRefundStatus(status?: string): RefundStatus {
+    switch ((status || "").toUpperCase()) {
+      case "SUCCESS":
+      case "COMPLETED":
+        return "completed";
+      case "PENDING":
+      case "IN_PROGRESS":
+        return "processing";
+      case "FAILED":
+      case "DECLINED":
+        return "failed";
+      case "CANCELLED":
+        return "cancelled";
+      default:
+        return "pending";
+    }
+  }
+
+  private detectMethod(method: string): PaymentMethod {
+    switch ((method || "").toLowerCase()) {
+      case "upi":
+        return "upi";
+      case "netbanking":
+        return "netbanking";
+      case "wallet":
+        return "wallet";
+      case "card":
+      case "credit_card":
+      case "debit_card":
+        return "card";
+      default:
+        return "card";
+    }
+  }
+}

--- a/server/adapters/ccavenue-adapter.ts
+++ b/server/adapters/ccavenue-adapter.ts
@@ -1,0 +1,489 @@
+import crypto from "crypto";
+import type {
+  PaymentsAdapter,
+  CreatePaymentParams,
+  PaymentResult,
+  VerifyPaymentParams,
+  CapturePaymentParams,
+  CreateRefundParams,
+  RefundResult,
+  WebhookVerifyParams,
+  WebhookVerifyResult,
+  HealthCheckParams,
+  HealthCheckResult,
+  PaymentMethod,
+  Currency,
+  PaymentStatus,
+  RefundStatus,
+} from "../../shared/payment-types";
+import type { PaymentProvider, Environment } from "../../shared/payment-providers";
+import type { ResolvedConfig } from "../services/config-resolver";
+import { PaymentError, RefundError, WebhookError } from "../../shared/payment-types";
+
+interface CCAvenueResponse {
+  status: string;
+  message?: string;
+  order_status?: string;
+  reference_no?: string;
+  order_no?: string;
+  tracking_id?: string;
+  amount?: string;
+  currency?: string;
+  status_code?: string;
+  status_message?: string;
+  error_code?: string;
+  error_desc?: string;
+  refund_status?: string;
+  refund_reference_no?: string;
+  refund_amount?: string;
+  payment_mode?: string;
+  data?: Record<string, any>;
+}
+
+export class CCAvenueAdapter implements PaymentsAdapter {
+  public readonly provider: PaymentProvider = "ccavenue";
+  public readonly environment: Environment;
+
+  private readonly merchantId: string;
+  private readonly accessCode: string;
+  private readonly workingKey: string;
+  private readonly baseUrl: string;
+  private readonly redirectBaseUrl: string;
+
+  constructor(private readonly config: ResolvedConfig) {
+    this.environment = config.environment;
+
+    this.merchantId = config.merchantId || "";
+    this.accessCode = config.accessCode || "";
+    this.workingKey = config.secrets.workingKey || "";
+
+    const isLive = this.environment === "live";
+    this.baseUrl = isLive
+      ? "https://api.ccavenue.com/apis/servlet/DoWebTrans"
+      : "https://apitest.ccavenue.com/apis/servlet/DoWebTrans";
+    this.redirectBaseUrl = isLive
+      ? "https://secure.ccavenue.com/transaction/transaction.do"
+      : "https://apitest.ccavenue.com/transaction/transaction.do";
+
+    if (!this.merchantId || !this.accessCode || !this.workingKey) {
+      throw new PaymentError(
+        "Missing CCAvenue credentials",
+        "MISSING_CREDENTIALS",
+        "ccavenue"
+      );
+    }
+  }
+
+  public async createPayment(params: CreatePaymentParams): Promise<PaymentResult> {
+    try {
+      const requestParams = new URLSearchParams({
+        merchant_id: this.merchantId,
+        order_id: params.orderId,
+        currency: params.currency,
+        amount: (params.orderAmount / 100).toFixed(2),
+        redirect_url: params.successUrl || "",
+        cancel_url: params.failureUrl || params.cancelUrl || "",
+        language: "EN",
+        billing_name: params.customer.name || "",
+        billing_tel: params.customer.phone || "",
+        billing_email: params.customer.email || "",
+      });
+
+      if (params.metadata) {
+        let index = 1;
+        for (const value of Object.values(params.metadata)) {
+          if (index > 5) break; // CCAvenue supports up to 5 merchant params
+          requestParams.append(`merchant_param${index}`, String(value));
+          index += 1;
+        }
+      }
+
+      const encRequest = this.encrypt(requestParams.toString());
+
+      const result: PaymentResult = {
+        paymentId: crypto.randomUUID(),
+        providerPaymentId: params.orderId,
+        providerOrderId: params.orderId,
+        status: "initiated",
+        amount: params.orderAmount,
+        currency: params.currency,
+        provider: "ccavenue",
+        environment: this.environment,
+        redirectUrl: `${this.redirectBaseUrl}?command=initiateTransaction&encRequest=${encodeURIComponent(encRequest)}&access_code=${encodeURIComponent(this.accessCode)}`,
+        providerData: {
+          encRequest,
+          accessCode: this.accessCode,
+          merchantId: this.merchantId,
+        },
+        createdAt: new Date(),
+      };
+
+      return result;
+    } catch (error) {
+      console.error("CCAvenue payment creation failed:", error);
+      throw new PaymentError(
+        `CCAvenue payment creation failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        "PAYMENT_CREATION_FAILED",
+        "ccavenue",
+        error
+      );
+    }
+  }
+
+  public async verifyPayment(params: VerifyPaymentParams): Promise<PaymentResult> {
+    try {
+      const orderId = params.providerPaymentId || params.paymentId;
+
+      if (!orderId) {
+        throw new PaymentError("Missing CCAvenue order identifier", "MISSING_VERIFICATION_DATA", "ccavenue");
+      }
+
+      const encRequest = this.encrypt(
+        JSON.stringify({
+          order_no: orderId,
+        })
+      );
+
+      const response = await this.invokeCommand(encRequest, "orderStatusTracker");
+      const parsed = this.parseResponse(response);
+
+      const result: PaymentResult = {
+        paymentId: params.paymentId,
+        providerPaymentId: parsed?.tracking_id || orderId,
+        providerOrderId: parsed?.order_no || orderId,
+        status: this.mapPaymentStatus(parsed?.order_status || "FAILED"),
+        amount: parsed?.amount ? Math.round(parseFloat(parsed.amount) * 100) : 0,
+        currency: (parsed?.currency as Currency) || "INR",
+        provider: "ccavenue",
+        environment: this.environment,
+        method: {
+          type: "card",
+          brand: parsed?.payment_mode,
+        },
+        providerData: parsed as Record<string, any>,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      return result;
+    } catch (error) {
+      console.error("CCAvenue payment verification failed:", error);
+      throw new PaymentError(
+        `Payment verification failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        "PAYMENT_VERIFICATION_FAILED",
+        "ccavenue",
+        error
+      );
+    }
+  }
+
+  public async capturePayment(params: CapturePaymentParams): Promise<PaymentResult> {
+    try {
+      // CCAvenue payments are typically auto-captured. We call verify to reflect status.
+      return this.verifyPayment({
+        paymentId: params.paymentId,
+        providerPaymentId: params.providerPaymentId,
+      });
+    } catch (error) {
+      console.error("CCAvenue capture failed:", error);
+      throw new PaymentError(
+        `Payment capture failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        "PAYMENT_CAPTURE_FAILED",
+        "ccavenue",
+        error
+      );
+    }
+  }
+
+  public async createRefund(params: CreateRefundParams): Promise<RefundResult> {
+    try {
+      const orderId = params.providerPaymentId;
+
+      if (!orderId) {
+        throw new RefundError("Missing CCAvenue order identifier", "MISSING_PROVIDER_PAYMENT_ID", "ccavenue");
+      }
+
+      const refundAmount = params.amount ? (params.amount / 100).toFixed(2) : undefined;
+
+      const encRequest = this.encrypt(
+        JSON.stringify({
+          order_no: orderId,
+          refund_amount: refundAmount,
+          refund_ref_no: `REF_${Date.now()}`,
+          refund_reason: params.reason,
+        })
+      );
+
+      const response = await this.invokeCommand(encRequest, "refundOrder");
+      const parsed = this.parseResponse(response);
+
+      const result: RefundResult = {
+        refundId: parsed?.refund_reference_no || crypto.randomUUID(),
+        paymentId: params.paymentId,
+        providerRefundId: parsed?.refund_reference_no,
+        amount: parsed?.refund_amount ? Math.round(parseFloat(parsed.refund_amount) * 100) : params.amount || 0,
+        status: this.mapRefundStatus(parsed?.refund_status || "PENDING"),
+        provider: "ccavenue",
+        environment: this.environment,
+        reason: params.reason,
+        notes: params.notes,
+        providerData: parsed as Record<string, any>,
+        createdAt: new Date(),
+      };
+
+      return result;
+    } catch (error) {
+      console.error("CCAvenue refund creation failed:", error);
+      throw new RefundError(
+        `Refund creation failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        "REFUND_CREATION_FAILED",
+        "ccavenue",
+        error
+      );
+    }
+  }
+
+  public async getRefundStatus(refundId: string): Promise<RefundResult> {
+    try {
+      const encRequest = this.encrypt(
+        JSON.stringify({
+          refund_ref_no: refundId,
+        })
+      );
+
+      const response = await this.invokeCommand(encRequest, "refundStatus");
+      const parsed = this.parseResponse(response);
+
+      const result: RefundResult = {
+        refundId: parsed?.refund_reference_no || refundId,
+        paymentId: parsed?.order_no || "",
+        providerRefundId: parsed?.refund_reference_no || refundId,
+        amount: parsed?.refund_amount ? Math.round(parseFloat(parsed.refund_amount) * 100) : 0,
+        status: this.mapRefundStatus(parsed?.refund_status || "PENDING"),
+        provider: "ccavenue",
+        environment: this.environment,
+        providerData: parsed as Record<string, any>,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      return result;
+    } catch (error) {
+      console.error("CCAvenue refund status check failed:", error);
+      throw new RefundError(
+        `Refund status check failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        "REFUND_STATUS_CHECK_FAILED",
+        "ccavenue",
+        error
+      );
+    }
+  }
+
+  public async verifyWebhook(params: WebhookVerifyParams): Promise<WebhookVerifyResult> {
+    try {
+      const payload = typeof params.body === "string" ? params.body : params.body.toString();
+      const search = new URLSearchParams(payload);
+      const encResp = search.get("encResp");
+
+      if (!encResp) {
+        throw new WebhookError("Missing encResp parameter", "MISSING_ENC_RESP", "ccavenue");
+      }
+
+      const decrypted = this.decrypt(encResp);
+      const parsed = this.parseResponseString(decrypted);
+
+      return {
+        verified: true,
+        event: {
+          type: "payment.update",
+          paymentId: parsed?.tracking_id || parsed?.order_no,
+          status: this.mapPaymentStatus(parsed?.order_status || ''),
+          data: parsed,
+        },
+        providerData: parsed,
+      };
+    } catch (error) {
+      console.error("CCAvenue webhook verification failed:", error);
+      return {
+        verified: false,
+        error: {
+          code: "WEBHOOK_VERIFICATION_FAILED",
+          message: error instanceof Error ? error.message : "Unknown error",
+        },
+      };
+    }
+  }
+
+  public async healthCheck(_params?: HealthCheckParams): Promise<HealthCheckResult> {
+    const start = Date.now();
+
+    try {
+      const encRequest = this.encrypt(JSON.stringify({ order_no: "PING" }));
+      await this.invokeCommand(encRequest, "orderStatusTracker");
+
+      const responseTime = Date.now() - start;
+
+      return {
+        provider: "ccavenue",
+        environment: this.environment,
+        healthy: true,
+        responseTime,
+        tests: {
+          connectivity: true,
+          authentication: true,
+          apiAccess: true,
+        },
+        timestamp: new Date(),
+      };
+    } catch (error) {
+      return {
+        provider: "ccavenue",
+        environment: this.environment,
+        healthy: false,
+        responseTime: Date.now() - start,
+        tests: {
+          connectivity: false,
+          authentication: false,
+          apiAccess: false,
+        },
+        error: {
+          code: "HEALTH_CHECK_FAILED",
+          message: error instanceof Error ? error.message : "Unknown error",
+        },
+        timestamp: new Date(),
+      };
+    }
+  }
+
+  public getSupportedMethods(): PaymentMethod[] {
+    return ["card", "upi", "netbanking", "wallet"];
+  }
+
+  public getSupportedCurrencies(): Currency[] {
+    return ["INR", "USD"]; // CCAvenue supports multi-currency
+  }
+
+  public async validateConfig(): Promise<{ valid: boolean; errors: string[] }> {
+    const errors: string[] = [];
+
+    if (!this.merchantId) {
+      errors.push("Missing CCAvenue Merchant ID");
+    }
+
+    if (!this.accessCode) {
+      errors.push("Missing CCAvenue Access Code");
+    }
+
+    if (!this.workingKey) {
+      errors.push("Missing CCAvenue Working Key");
+    }
+
+    return { valid: errors.length === 0, errors };
+  }
+
+  private async invokeCommand(encRequest: string, command: string): Promise<string> {
+    const form = new URLSearchParams({
+      command,
+      enc_request: encRequest,
+      access_code: this.accessCode,
+      request_type: "JSON",
+      response_type: "JSON",
+    });
+
+    const response = await fetch(this.baseUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "User-Agent": "PaymentApp/1.0",
+      },
+      body: form.toString(),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`CCAvenue API error: ${response.status} ${text}`);
+    }
+
+    return response.text();
+  }
+
+  private parseResponse(response: string): CCAvenueResponse {
+    const search = new URLSearchParams(response);
+    const encResponse = search.get("enc_response") || search.get("encResponse");
+    if (!encResponse) {
+      return {} as CCAvenueResponse;
+    }
+
+    const decrypted = this.decrypt(encResponse);
+    return this.parseResponseString(decrypted);
+  }
+
+  private parseResponseString(text: string): CCAvenueResponse {
+    try {
+      return JSON.parse(text);
+    } catch {
+      const params = new URLSearchParams(text);
+      const obj: Record<string, any> = {};
+      params.forEach((value, key) => {
+        obj[key] = value;
+      });
+      return obj as CCAvenueResponse;
+    }
+  }
+
+  private mapPaymentStatus(status: string): PaymentStatus {
+    switch ((status || "").toUpperCase()) {
+      case "INITIATED":
+        return "initiated";
+      case "IN PROGRESS":
+      case "PENDING":
+        return "processing";
+      case "SUCCESS":
+      case "CAPTURED":
+        return "captured";
+      case "AUTHORIZATION":
+        return "authorized";
+      case "REFUND":
+      case "REFUNDED":
+        return "refunded";
+      case "FAILURE":
+      case "FAILED":
+      case "CANCELLED":
+        return "failed";
+      default:
+        return "failed";
+    }
+  }
+
+  private mapRefundStatus(status: string): RefundStatus {
+    switch ((status || "").toUpperCase()) {
+      case "SUCCESS":
+      case "PROCESSED":
+        return "completed";
+      case "PENDING":
+      case "IN PROGRESS":
+        return "processing";
+      case "FAILED":
+      case "DECLINED":
+        return "failed";
+      case "CANCELLED":
+        return "cancelled";
+      default:
+        return "pending";
+    }
+  }
+
+  private encrypt(plainText: string): string {
+    const key = crypto.createHash("md5").update(this.workingKey).digest();
+    const iv = crypto.createHash("md5").update(key).digest();
+    const cipher = crypto.createCipheriv("aes-128-cbc", key, iv);
+    return cipher.update(plainText, "utf8", "hex") + cipher.final("hex");
+  }
+
+  private decrypt(cipherText: string): string {
+    const key = crypto.createHash("md5").update(this.workingKey).digest();
+    const iv = crypto.createHash("md5").update(key).digest();
+    const decipher = crypto.createDecipheriv("aes-128-cbc", key, iv);
+    return decipher.update(cipherText, "hex", "utf8") + decipher.final("utf8");
+  }
+}

--- a/server/adapters/paytm-adapter.ts
+++ b/server/adapters/paytm-adapter.ts
@@ -1,0 +1,533 @@
+import crypto from "crypto";
+import type {
+  PaymentsAdapter,
+  CreatePaymentParams,
+  PaymentResult,
+  VerifyPaymentParams,
+  CapturePaymentParams,
+  CreateRefundParams,
+  RefundResult,
+  WebhookVerifyParams,
+  WebhookVerifyResult,
+  HealthCheckParams,
+  HealthCheckResult,
+  PaymentMethod,
+  Currency,
+  PaymentStatus,
+  RefundStatus,
+} from "../../shared/payment-types";
+import type { PaymentProvider, Environment } from "../../shared/payment-providers";
+import type { ResolvedConfig } from "../services/config-resolver";
+import { PaymentError, RefundError, WebhookError } from "../../shared/payment-types";
+
+interface PaytmInitiateTransactionResponse {
+  body: {
+    resultInfo: {
+      resultStatus: string;
+      resultCode: string;
+      resultMsg: string;
+    };
+    txnToken?: string;
+    bankForm?: Record<string, any>;
+  };
+  head?: Record<string, any>;
+}
+
+interface PaytmOrderStatusResponse {
+  body: {
+    resultInfo: {
+      resultStatus: string;
+      resultCode: string;
+      resultMsg: string;
+    };
+    orderId: string;
+    txnId?: string;
+    bankTxnId?: string;
+    txnAmount?: string;
+    txnDate?: string;
+    paymentMode?: string;
+    currency?: string;
+    gatewayName?: string;
+    bankName?: string;
+    mid?: string;
+  };
+}
+
+interface PaytmRefundResponse {
+  body: {
+    resultInfo: {
+      resultStatus: string;
+      resultCode: string;
+      resultMsg: string;
+    };
+    refundId: string;
+    txnId?: string;
+    orderId?: string;
+    refundAmount?: string;
+  };
+}
+
+export class PaytmAdapter implements PaymentsAdapter {
+  public readonly provider: PaymentProvider = "paytm";
+  public readonly environment: Environment;
+
+  private readonly merchantId: string;
+  private readonly merchantKey: string;
+  private readonly websiteName: string;
+  private readonly baseUrl: string;
+
+  constructor(private readonly config: ResolvedConfig) {
+    this.environment = config.environment;
+
+    this.merchantId = config.merchantId || "";
+    this.merchantKey = config.secrets.merchantKey || "";
+    this.websiteName = config.metadata?.websiteName || (this.environment === "live" ? "DEFAULT" : "WEBSTAGING");
+
+    this.baseUrl = this.environment === "live"
+      ? "https://securegw.paytm.in"
+      : "https://securegw-stage.paytm.in";
+
+    if (!this.merchantId || !this.merchantKey) {
+      throw new PaymentError(
+        "Missing Paytm credentials",
+        "MISSING_CREDENTIALS",
+        "paytm"
+      );
+    }
+  }
+
+  public async createPayment(params: CreatePaymentParams): Promise<PaymentResult> {
+    try {
+      const body = {
+        requestType: "Payment",
+        mid: this.merchantId,
+        websiteName: this.websiteName,
+        orderId: params.orderId,
+        callbackUrl: params.successUrl,
+        txnAmount: {
+          value: (params.orderAmount / 100).toFixed(2),
+          currency: params.currency,
+        },
+        userInfo: {
+          custId: params.customer.id || params.customer.email || params.customer.phone || `CUST_${Date.now()}`,
+          email: params.customer.email,
+          mobile: params.customer.phone,
+        },
+      };
+
+      const head = {
+        signature: this.generateSignature(body),
+      };
+
+      const payload = { body, head };
+
+      const response = await this.makeApiCall<PaytmInitiateTransactionResponse>(
+        `/theia/api/v1/initiateTransaction?mid=${this.merchantId}&orderId=${params.orderId}`,
+        "POST",
+        payload
+      );
+
+      if (response.body.resultInfo.resultStatus !== "S") {
+        throw new Error(response.body.resultInfo.resultMsg);
+      }
+
+      const result: PaymentResult = {
+        paymentId: crypto.randomUUID(),
+        providerPaymentId: params.orderId,
+        providerOrderId: params.orderId,
+        status: "initiated",
+        amount: params.orderAmount,
+        currency: params.currency,
+        provider: "paytm",
+        environment: this.environment,
+        providerData: {
+          txnToken: response.body.txnToken,
+          orderId: params.orderId,
+          mid: this.merchantId,
+        },
+        createdAt: new Date(),
+      };
+
+      return result;
+    } catch (error) {
+      console.error("Paytm payment creation failed:", error);
+      throw new PaymentError(
+        `Paytm payment creation failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        "PAYMENT_CREATION_FAILED",
+        "paytm",
+        error
+      );
+    }
+  }
+
+  public async verifyPayment(params: VerifyPaymentParams): Promise<PaymentResult> {
+    try {
+      const orderId = params.providerPaymentId || params.paymentId;
+
+      if (!orderId) {
+        throw new PaymentError("Missing Paytm order identifier", "MISSING_VERIFICATION_DATA", "paytm");
+      }
+
+      const body = {
+        mid: this.merchantId,
+        orderId,
+      };
+
+      const payload = {
+        body,
+        head: {
+          signature: this.generateSignature(body),
+        },
+      };
+
+      const response = await this.makeApiCall<PaytmOrderStatusResponse>(
+        "/v3/order/status",
+        "POST",
+        payload
+      );
+
+      const info = response.body;
+
+      const result: PaymentResult = {
+        paymentId: params.paymentId,
+        providerPaymentId: info.txnId || orderId,
+        providerOrderId: info.orderId,
+        status: this.mapPaymentStatus(info.resultInfo.resultStatus),
+        amount: info.txnAmount ? Math.round(parseFloat(info.txnAmount) * 100) : 0,
+        currency: (info.currency as Currency) || "INR",
+        provider: "paytm",
+        environment: this.environment,
+        method: info.paymentMode ? { type: this.detectMethod(info.paymentMode), brand: info.bankName } : undefined,
+        providerData: info,
+        createdAt: info.txnDate ? new Date(info.txnDate) : new Date(),
+        updatedAt: new Date(),
+      };
+
+      return result;
+    } catch (error) {
+      console.error("Paytm payment verification failed:", error);
+      throw new PaymentError(
+        `Payment verification failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        "PAYMENT_VERIFICATION_FAILED",
+        "paytm",
+        error
+      );
+    }
+  }
+
+  public async capturePayment(params: CapturePaymentParams): Promise<PaymentResult> {
+    try {
+      // Paytm auto-captures UPI/card payments. Return verification result.
+      return this.verifyPayment({
+        paymentId: params.paymentId,
+        providerPaymentId: params.providerPaymentId,
+      });
+    } catch (error) {
+      console.error("Paytm capture failed:", error);
+      throw new PaymentError(
+        `Payment capture failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        "PAYMENT_CAPTURE_FAILED",
+        "paytm",
+        error
+      );
+    }
+  }
+
+  public async createRefund(params: CreateRefundParams): Promise<RefundResult> {
+    try {
+      const orderId = params.providerPaymentId;
+
+      if (!orderId) {
+        throw new RefundError("Missing Paytm order identifier", "MISSING_PROVIDER_PAYMENT_ID", "paytm");
+      }
+
+      const body = {
+        mid: this.merchantId,
+        orderId,
+        txnType: "REFUND",
+        refId: `REF_${Date.now()}`,
+        txnId: params.paymentId,
+        refundAmount: params.amount ? (params.amount / 100).toFixed(2) : undefined,
+      };
+
+      const payload = {
+        body,
+        head: {
+          signature: this.generateSignature(body),
+        },
+      };
+
+      const response = await this.makeApiCall<PaytmRefundResponse>(
+        "/refund/apply",
+        "POST",
+        payload
+      );
+
+      const info = response.body;
+
+      const result: RefundResult = {
+        refundId: info.refundId,
+        paymentId: params.paymentId,
+        providerRefundId: info.refundId,
+        amount: info.refundAmount ? Math.round(parseFloat(info.refundAmount) * 100) : params.amount || 0,
+        status: this.mapRefundStatus(info.resultInfo.resultStatus),
+        provider: "paytm",
+        environment: this.environment,
+        reason: params.reason,
+        notes: params.notes,
+        providerData: info,
+        createdAt: new Date(),
+      };
+
+      return result;
+    } catch (error) {
+      console.error("Paytm refund creation failed:", error);
+      throw new RefundError(
+        `Refund creation failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        "REFUND_CREATION_FAILED",
+        "paytm",
+        error
+      );
+    }
+  }
+
+  public async getRefundStatus(refundId: string): Promise<RefundResult> {
+    try {
+      const body = {
+        mid: this.merchantId,
+        refundId,
+      };
+
+      const payload = {
+        body,
+        head: {
+          signature: this.generateSignature(body),
+        },
+      };
+
+      const response = await this.makeApiCall<PaytmRefundResponse>(
+        "/v3/refund/status",
+        "POST",
+        payload
+      );
+
+      const info = response.body;
+
+      const result: RefundResult = {
+        refundId: info.refundId || refundId,
+        paymentId: info.orderId || "",
+        providerRefundId: info.refundId || refundId,
+        amount: info.refundAmount ? Math.round(parseFloat(info.refundAmount) * 100) : 0,
+        status: this.mapRefundStatus(info.resultInfo.resultStatus),
+        provider: "paytm",
+        environment: this.environment,
+        providerData: info,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      return result;
+    } catch (error) {
+      console.error("Paytm refund status check failed:", error);
+      throw new RefundError(
+        `Refund status check failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        "REFUND_STATUS_CHECK_FAILED",
+        "paytm",
+        error
+      );
+    }
+  }
+
+  public async verifyWebhook(params: WebhookVerifyParams): Promise<WebhookVerifyResult> {
+    try {
+      const signature = params.headers["x-paytm-signature"] || params.signature;
+
+      if (!signature) {
+        return { verified: false, error: { code: "MISSING_SIGNATURE", message: "Missing Paytm signature" } };
+      }
+
+      const body = params.body.toString();
+      const expected = this.generateSignature(body);
+
+      if (signature !== expected) {
+        return { verified: false, error: { code: "INVALID_SIGNATURE", message: "Invalid webhook signature" } };
+      }
+
+      const payload = JSON.parse(body);
+
+      return {
+        verified: true,
+        event: {
+          type: payload.eventType || "payment.update",
+          paymentId: payload.orderId,
+          refundId: payload.refundId,
+          status: payload.status,
+          data: payload,
+        },
+        providerData: payload,
+      };
+    } catch (error) {
+      console.error("Paytm webhook verification failed:", error);
+      return {
+        verified: false,
+        error: {
+          code: "WEBHOOK_VERIFICATION_FAILED",
+          message: error instanceof Error ? error.message : "Unknown error",
+        },
+      };
+    }
+  }
+
+  public async healthCheck(_params?: HealthCheckParams): Promise<HealthCheckResult> {
+    const start = Date.now();
+
+    try {
+      const body = { mid: this.merchantId, orderId: "PING" };
+      await this.makeApiCall(
+        "/v3/order/status",
+        "POST",
+        { body, head: { signature: this.generateSignature(body) } }
+      );
+
+      const responseTime = Date.now() - start;
+
+      return {
+        provider: "paytm",
+        environment: this.environment,
+        healthy: true,
+        responseTime,
+        tests: {
+          connectivity: true,
+          authentication: true,
+          apiAccess: true,
+        },
+        timestamp: new Date(),
+      };
+    } catch (error) {
+      return {
+        provider: "paytm",
+        environment: this.environment,
+        healthy: false,
+        responseTime: Date.now() - start,
+        tests: {
+          connectivity: false,
+          authentication: false,
+          apiAccess: false,
+        },
+        error: {
+          code: "HEALTH_CHECK_FAILED",
+          message: error instanceof Error ? error.message : "Unknown error",
+        },
+        timestamp: new Date(),
+      };
+    }
+  }
+
+  public getSupportedMethods(): PaymentMethod[] {
+    return ["card", "upi", "netbanking", "wallet"];
+  }
+
+  public getSupportedCurrencies(): Currency[] {
+    return ["INR"];
+  }
+
+  public async validateConfig(): Promise<{ valid: boolean; errors: string[] }> {
+    const errors: string[] = [];
+
+    if (!this.merchantId) {
+      errors.push("Missing Paytm Merchant ID");
+    }
+
+    if (!this.merchantKey) {
+      errors.push("Missing Paytm Merchant Key");
+    }
+
+    return { valid: errors.length === 0, errors };
+  }
+
+  private async makeApiCall<T>(endpoint: string, method: "GET" | "POST", data?: any): Promise<T> {
+    const url = `${this.baseUrl}${endpoint}`;
+
+    const response = await fetch(url, {
+      method,
+      headers: {
+        "Content-Type": "application/json",
+        "User-Agent": "PaymentApp/1.0",
+      },
+      body: data ? JSON.stringify(data) : undefined,
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Paytm API error: ${response.status} ${text}`);
+    }
+
+    return response.json() as Promise<T>;
+  }
+
+  private generateSignature(data: any): string {
+    const stringPayload = typeof data === "string" ? data : JSON.stringify(data);
+    return crypto
+      .createHmac("sha256", this.merchantKey)
+      .update(stringPayload, "utf8")
+      .digest("base64");
+  }
+
+  private mapPaymentStatus(status: string): PaymentStatus {
+    switch ((status || "").toUpperCase()) {
+      case "S":
+      case "SUCCESS":
+        return "captured";
+      case "PENDING":
+      case "P":
+        return "processing";
+      case "INITIATED":
+        return "initiated";
+      case "TXN_SUCCESS":
+        return "captured";
+      case "TXN_FAILURE":
+      case "F":
+      case "FAILURE":
+        return "failed";
+      case "REFUNDED":
+        return "refunded";
+      default:
+        return "failed";
+    }
+  }
+
+  private mapRefundStatus(status: string): RefundStatus {
+    switch ((status || "").toUpperCase()) {
+      case "SUCCESS":
+      case "REFUND_SUCCESS":
+        return "completed";
+      case "PENDING":
+      case "PROCESSING":
+        return "processing";
+      case "FAILURE":
+      case "FAILED":
+        return "failed";
+      case "CANCELLED":
+        return "cancelled";
+      default:
+        return "pending";
+    }
+  }
+
+  private detectMethod(mode: string): PaymentMethod {
+    switch ((mode || "").toLowerCase()) {
+      case "upi":
+        return "upi";
+      case "netbanking":
+        return "netbanking";
+      case "wallet":
+        return "wallet";
+      case "creditcard":
+      case "debitcard":
+      case "card":
+        return "card";
+      default:
+        return "card";
+    }
+  }
+}

--- a/server/adapters/payu-adapter.ts
+++ b/server/adapters/payu-adapter.ts
@@ -1,0 +1,539 @@
+import crypto from "crypto";
+import type {
+  PaymentsAdapter,
+  CreatePaymentParams,
+  PaymentResult,
+  VerifyPaymentParams,
+  CapturePaymentParams,
+  CreateRefundParams,
+  RefundResult,
+  WebhookVerifyParams,
+  WebhookVerifyResult,
+  HealthCheckResult,
+  HealthCheckParams,
+  PaymentMethod,
+  Currency,
+  PaymentStatus,
+  RefundStatus,
+} from "../../shared/payment-types";
+import type { PaymentProvider, Environment } from "../../shared/payment-providers";
+import type { ResolvedConfig } from "../services/config-resolver";
+import { PaymentError, RefundError } from "../../shared/payment-types";
+
+interface PayUOrderResponse {
+  status: string;
+  message?: string;
+  result?: {
+    orderId?: string;
+    txnId?: string;
+    mihpayid?: string;
+    status?: string;
+    amount?: string;
+    currency?: string;
+    created_at?: string;
+  };
+  error?: string;
+  data?: Record<string, any>;
+}
+
+interface PayUPaymentStatusResponse {
+  status: string;
+  message?: string;
+  result?: {
+    orderId?: string;
+    txnId?: string;
+    mihpayid?: string;
+    amount?: string;
+    currency?: string;
+    status?: string;
+    addedon?: string;
+    paymentSource?: string;
+    cardType?: string;
+    bankRefNum?: string;
+  };
+  error?: string;
+}
+
+interface PayURefundResponse {
+  status: string;
+  message?: string;
+  result?: {
+    requestId?: string;
+    refundId?: string;
+    status?: string;
+    amount?: string;
+    createdAt?: string;
+  };
+  error?: string;
+}
+
+export class PayUAdapter implements PaymentsAdapter {
+  public readonly provider: PaymentProvider = "payu";
+  public readonly environment: Environment;
+
+  private readonly merchantKey: string;
+  private readonly salt: string;
+  private readonly baseUrl: string;
+
+  constructor(private readonly config: ResolvedConfig) {
+    this.environment = config.environment;
+
+    this.merchantKey = config.keyId || "";
+    this.salt = config.secrets.salt || "";
+
+    this.baseUrl = this.environment === "live"
+      ? "https://secure.payu.in"
+      : "https://test.payu.in";
+
+    if (!this.merchantKey || !this.salt) {
+      throw new PaymentError(
+        "Missing PayU credentials",
+        "MISSING_CREDENTIALS",
+        "payu"
+      );
+    }
+  }
+
+  public async createPayment(params: CreatePaymentParams): Promise<PaymentResult> {
+    try {
+      const txnId = params.orderId || `PAYU_${Date.now()}`;
+
+      const payload = {
+        merchantKey: this.merchantKey,
+        txnId,
+        amount: params.orderAmount / 100,
+        currency: params.currency,
+        callbackUrl: params.successUrl,
+        redirectUrl: params.successUrl,
+        customer: {
+          name: params.customer.name,
+          email: params.customer.email,
+          phone: params.customer.phone,
+        },
+        metadata: params.metadata,
+      };
+
+      const response = await this.makeApiCall<PayUOrderResponse>(
+        "/api/v2_1/orders",
+        "POST",
+        payload
+      );
+
+      if (!response || response.status?.toUpperCase() !== "SUCCESS") {
+        throw new Error(response?.message || response?.error || "Unable to create PayU order");
+      }
+
+      const result: PaymentResult = {
+        paymentId: crypto.randomUUID(),
+        providerPaymentId: response.result?.mihpayid || txnId,
+        providerOrderId: response.result?.orderId || txnId,
+        status: this.mapPaymentStatus(response.result?.status || "INITIATED"),
+        amount: params.orderAmount,
+        currency: params.currency,
+        provider: "payu",
+        environment: this.environment,
+        redirectUrl: response.result?.orderId
+          ? `${this.baseUrl}/_payment?orderId=${encodeURIComponent(response.result.orderId)}`
+          : undefined,
+        method: params.preferredMethod
+          ? { type: params.preferredMethod }
+          : undefined,
+        providerData: {
+          orderId: response.result?.orderId || txnId,
+          txnId,
+          mihpayid: response.result?.mihpayid,
+          status: response.result?.status,
+        },
+        createdAt: new Date(),
+      };
+
+      return result;
+    } catch (error) {
+      console.error("PayU payment creation failed:", error);
+      throw new PaymentError(
+        `PayU payment creation failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        "PAYMENT_CREATION_FAILED",
+        "payu",
+        error
+      );
+    }
+  }
+
+  public async verifyPayment(params: VerifyPaymentParams): Promise<PaymentResult> {
+    try {
+      const providerOrderId =
+        params.providerPaymentId || (params.providerData as any)?.orderId || params.paymentId;
+
+      if (!providerOrderId) {
+        throw new PaymentError("Missing PayU transaction identifier", "MISSING_VERIFICATION_DATA", "payu");
+      }
+
+      const response = await this.makeApiCall<PayUPaymentStatusResponse>(
+        `/api/v2_1/orders/${providerOrderId}`,
+        "GET"
+      );
+
+      if (!response || response.status?.toUpperCase() !== "SUCCESS") {
+        throw new Error(response?.message || response?.error || "Failed to fetch PayU status");
+      }
+
+      const result: PaymentResult = {
+        paymentId: params.paymentId,
+        providerPaymentId: response.result?.mihpayid || providerOrderId,
+        providerOrderId: response.result?.orderId || providerOrderId,
+        status: this.mapPaymentStatus(response.result?.status || "FAILED"),
+        amount: response.result?.amount ? Math.round(parseFloat(response.result.amount) * 100) : 0,
+        currency: (response.result?.currency as Currency) || "INR",
+        provider: "payu",
+        environment: this.environment,
+        method: {
+          type: this.detectMethod(response.result?.paymentSource),
+          brand: response.result?.cardType,
+          last4: response.result?.bankRefNum?.slice(-4),
+        },
+        providerData: {
+          orderId: response.result?.orderId || providerOrderId,
+          txnId: response.result?.txnId,
+          mihpayid: response.result?.mihpayid,
+          status: response.result?.status,
+        },
+        createdAt: response.result?.addedon ? new Date(response.result.addedon) : new Date(),
+        updatedAt: new Date(),
+      };
+
+      return result;
+    } catch (error) {
+      console.error("PayU payment verification failed:", error);
+      throw new PaymentError(
+        `Payment verification failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        "PAYMENT_VERIFICATION_FAILED",
+        "payu",
+        error
+      );
+    }
+  }
+
+  public async capturePayment(params: CapturePaymentParams): Promise<PaymentResult> {
+    try {
+      const providerPaymentId = params.providerPaymentId || params.paymentId;
+
+      if (!providerPaymentId) {
+        throw new PaymentError("Missing PayU payment identifier", "MISSING_PROVIDER_PAYMENT_ID", "payu");
+      }
+
+      const response = await this.makeApiCall<PayUPaymentStatusResponse>(
+        `/api/v2_1/payments/${providerPaymentId}/capture`,
+        "POST",
+        params.amount ? { amount: params.amount / 100 } : undefined
+      );
+
+      if (!response || response.status?.toUpperCase() !== "SUCCESS") {
+        throw new Error(response?.message || response?.error || "Failed to capture PayU payment");
+      }
+
+      const paymentStatus = await this.verifyPayment({
+        paymentId: params.paymentId,
+        providerPaymentId: providerPaymentId,
+      });
+
+      return paymentStatus;
+    } catch (error) {
+      console.error("PayU capture failed:", error);
+      throw new PaymentError(
+        `Payment capture failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        "PAYMENT_CAPTURE_FAILED",
+        "payu",
+        error
+      );
+    }
+  }
+
+  public async createRefund(params: CreateRefundParams): Promise<RefundResult> {
+    try {
+      const providerPaymentId = params.providerPaymentId;
+
+      if (!providerPaymentId) {
+        throw new RefundError("Missing PayU payment identifier", "MISSING_PROVIDER_PAYMENT_ID", "payu");
+      }
+
+      const requestPayload = {
+        paymentId: providerPaymentId,
+        amount: params.amount ? params.amount / 100 : undefined,
+        reason: params.reason,
+        notes: params.notes,
+      };
+
+      const response = await this.makeApiCall<PayURefundResponse>(
+        "/api/v2_1/refunds",
+        "POST",
+        requestPayload
+      );
+
+      if (!response || response.status?.toUpperCase() !== "SUCCESS") {
+        throw new Error(response?.message || response?.error || "Failed to create PayU refund");
+      }
+
+      const result: RefundResult = {
+        refundId: response.result?.refundId || crypto.randomUUID(),
+        paymentId: params.paymentId,
+        providerRefundId: response.result?.refundId,
+        amount: params.amount || (response.result?.amount ? Math.round(parseFloat(response.result.amount) * 100) : 0),
+        status: this.mapRefundStatus(response.result?.status || "PENDING"),
+        provider: "payu",
+        environment: this.environment,
+        reason: params.reason,
+        notes: params.notes,
+        providerData: {
+          requestId: response.result?.requestId,
+          refundId: response.result?.refundId,
+          status: response.result?.status,
+        },
+        createdAt: response.result?.createdAt ? new Date(response.result.createdAt) : new Date(),
+      };
+
+      return result;
+    } catch (error) {
+      console.error("PayU refund creation failed:", error);
+      throw new RefundError(
+        `Refund creation failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        "REFUND_CREATION_FAILED",
+        "payu",
+        error
+      );
+    }
+  }
+
+  public async getRefundStatus(refundId: string): Promise<RefundResult> {
+    try {
+      const response = await this.makeApiCall<PayURefundResponse>(
+        `/api/v2_1/refunds/${refundId}`,
+        "GET"
+      );
+
+      if (!response || response.status?.toUpperCase() !== "SUCCESS") {
+        throw new Error(response?.message || response?.error || "Failed to fetch PayU refund status");
+      }
+
+      const result: RefundResult = {
+        refundId: response.result?.refundId || refundId,
+        paymentId: response.result?.requestId || "",
+        providerRefundId: response.result?.refundId || refundId,
+        amount: response.result?.amount ? Math.round(parseFloat(response.result.amount) * 100) : 0,
+        status: this.mapRefundStatus(response.result?.status || "PENDING"),
+        provider: "payu",
+        environment: this.environment,
+        providerData: {
+          requestId: response.result?.requestId,
+          status: response.result?.status,
+        },
+        createdAt: response.result?.createdAt ? new Date(response.result.createdAt) : new Date(),
+        updatedAt: new Date(),
+      };
+
+      return result;
+    } catch (error) {
+      console.error("PayU refund status check failed:", error);
+      throw new RefundError(
+        `Refund status check failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        "REFUND_STATUS_CHECK_FAILED",
+        "payu",
+        error
+      );
+    }
+  }
+
+  public async verifyWebhook(params: WebhookVerifyParams): Promise<WebhookVerifyResult> {
+    try {
+      const signature = params.headers["x-payu-signature"] || params.signature;
+
+      if (!signature) {
+        return { verified: false, error: { code: "MISSING_SIGNATURE", message: "Missing PayU signature header" } };
+      }
+
+      const bodyString = params.body.toString();
+      const expected = crypto
+        .createHmac("sha256", this.salt)
+        .update(bodyString, "utf8")
+        .digest("hex");
+
+      const isValid = this.safeCompare(signature, expected);
+
+      if (!isValid) {
+        return { verified: false, error: { code: "INVALID_SIGNATURE", message: "Invalid webhook signature" } };
+      }
+
+      const payload = JSON.parse(bodyString);
+      const eventType = payload.event || payload.type || "payment.update";
+      const data = payload.data || payload;
+
+      return {
+        verified: true,
+        event: {
+          type: eventType,
+          paymentId: data?.mihpayid || data?.txnId,
+          refundId: data?.refundId,
+          status: data?.status,
+          data,
+        },
+        providerData: payload,
+      };
+    } catch (error) {
+      console.error("PayU webhook verification failed:", error);
+      return {
+        verified: false,
+        error: {
+          code: "WEBHOOK_VERIFICATION_FAILED",
+          message: error instanceof Error ? error.message : "Unknown error",
+        },
+      };
+    }
+  }
+
+  public async healthCheck(_params?: HealthCheckParams): Promise<HealthCheckResult> {
+    const start = Date.now();
+
+    try {
+      await this.makeApiCall<PayUPaymentStatusResponse>("/api/v2_1/orders?limit=1", "GET");
+
+      const responseTime = Date.now() - start;
+
+      return {
+        provider: "payu",
+        environment: this.environment,
+        healthy: true,
+        responseTime,
+        tests: {
+          connectivity: true,
+          authentication: true,
+          apiAccess: true,
+        },
+        timestamp: new Date(),
+      };
+    } catch (error) {
+      return {
+        provider: "payu",
+        environment: this.environment,
+        healthy: false,
+        responseTime: Date.now() - start,
+        tests: {
+          connectivity: false,
+          authentication: false,
+          apiAccess: false,
+        },
+        error: {
+          code: "HEALTH_CHECK_FAILED",
+          message: error instanceof Error ? error.message : "Unknown error",
+        },
+        timestamp: new Date(),
+      };
+    }
+  }
+
+  public getSupportedMethods(): PaymentMethod[] {
+    return ["card", "upi", "netbanking", "wallet"];
+  }
+
+  public getSupportedCurrencies(): Currency[] {
+    return ["INR"];
+  }
+
+  public async validateConfig(): Promise<{ valid: boolean; errors: string[] }> {
+    const errors: string[] = [];
+
+    if (!this.merchantKey) {
+      errors.push("Missing PayU Merchant Key");
+    }
+
+    if (!this.salt) {
+      errors.push("Missing PayU Salt");
+    }
+
+    return { valid: errors.length === 0, errors };
+  }
+
+  private async makeApiCall<T>(endpoint: string, method: "GET" | "POST" | "PUT" | "DELETE", data?: any): Promise<T> {
+    const url = endpoint.startsWith("http") ? endpoint : `${this.baseUrl}${endpoint}`;
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      "Authorization": `Basic ${Buffer.from(`${this.merchantKey}:${this.salt}`).toString("base64")}`,
+      "User-Agent": "PaymentApp/1.0",
+    };
+
+    const response = await fetch(url, {
+      method,
+      headers,
+      body: data ? JSON.stringify(data) : undefined,
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`PayU API error: ${response.status} ${text}`);
+    }
+
+    if (response.status === 204) {
+      return {} as T;
+    }
+
+    return response.json() as Promise<T>;
+  }
+
+  private mapPaymentStatus(status: string): PaymentStatus {
+    switch (status?.toUpperCase()) {
+      case "INITIATED":
+      case "PENDING":
+        return "processing";
+      case "SUCCESS":
+      case "CAPTURED":
+        return "captured";
+      case "AUTHORIZING":
+        return "authorized";
+      case "FAILED":
+      case "CANCELLED":
+        return "failed";
+      case "REFUNDED":
+        return "refunded";
+      default:
+        return "failed";
+    }
+  }
+
+  private mapRefundStatus(status: string): RefundStatus {
+    switch (status?.toUpperCase()) {
+      case "SUCCESS":
+      case "PROCESSED":
+        return "completed";
+      case "PENDING":
+      case "INITIATED":
+        return "processing";
+      case "FAILED":
+      case "DECLINED":
+        return "failed";
+      case "CANCELLED":
+        return "cancelled";
+      default:
+        return "pending";
+    }
+  }
+
+  private detectMethod(source?: string | null): PaymentMethod {
+    switch ((source || "").toLowerCase()) {
+      case "upi":
+        return "upi";
+      case "netbanking":
+        return "netbanking";
+      case "wallet":
+        return "wallet";
+      default:
+        return "card";
+    }
+  }
+
+  private safeCompare(a: string, b: string): boolean {
+    try {
+      return crypto.timingSafeEqual(Buffer.from(a, "hex"), Buffer.from(b, "hex"));
+    } catch {
+      return false;
+    }
+  }
+}

--- a/server/adapters/razorpay-adapter.ts
+++ b/server/adapters/razorpay-adapter.ts
@@ -300,7 +300,7 @@ export class RazorpayAdapter implements PaymentsAdapter {
    */
   public async createRefund(params: CreateRefundParams): Promise<RefundResult> {
     try {
-      const providerPaymentId = params.providerPaymentId || params.paymentId;
+      const providerPaymentId = params.providerPaymentId;
       if (!providerPaymentId) {
         throw new RefundError('Missing Razorpay payment identifier', 'MISSING_PROVIDER_PAYMENT_ID', 'razorpay');
       }


### PR DESCRIPTION
## Summary
- add complete adapter implementations for PayU, CCAvenue, Cashfree, Paytm, and BillDesk so that each provider supports payment, refund, webhook, and health-check flows
- tighten existing adapters by fixing the Razorpay refund identifier handling and correcting PhonePe checksum, refund status, and webhook verification logic
- enhance the webhook router to auto-discover tenant-enabled providers, apply tenant-aware dedupe keys, and document the revised behaviour for operations teams

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d5200fcb44832aab1bdd7d4c305eb6