### PR TITLE
Handle missing payment provider secrets

### DIFF
--- a/server/services/adapter-factory.ts
+++ b/server/services/adapter-factory.ts
@@ -160,7 +160,19 @@ export class AdapterFactory implements PaymentAdapterFactory {
     }
 
     // Resolve configuration
-    const config = await configResolver.resolveConfig(provider, environment, tenantId);
+    let config: ResolvedConfig;
+    try {
+      config = await configResolver.resolveConfig(provider, environment, tenantId);
+    } catch (error) {
+      if (error instanceof ConfigurationError) {
+        throw error;
+      }
+
+      throw new ConfigurationError(
+        `Failed to resolve configuration for ${provider} (${environment})`,
+        provider
+      );
+    }
 
     // Validate configuration
     if (!config.enabled) {


### PR DESCRIPTION
## Summary
- raise configuration errors when required PAYAPP_* secrets are missing and avoid caching incomplete results
- surface secret resolution failures through the config resolver and adapter factory so misconfigured providers fail fast

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d5bbb1d114832aa8e66538a2dd23ad