### PR TITLE
Add PhonePe return reconciliation endpoint and thank-you polling gate

### DIFF
--- a/client/src/pages/__tests__/thank-you.test.tsx
+++ b/client/src/pages/__tests__/thank-you.test.tsx
@@ -14,7 +14,10 @@ describe("Thank-you page", () => {
   beforeEach(() => {
     setLocationMock.mockReset();
     sessionStorage.clear();
-    global.fetch = vi.fn();
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ status: "processing", message: "Processing" }),
+    }) as unknown as typeof fetch;
     window.history.replaceState({}, "", "/thank-you?orderId=order-1");
   });
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -40,6 +40,7 @@ Both refactors improved maintainability but did not change **endpoint URLs** or 
    - The payment controller now requires an `Idempotency-Key` header for `POST /api/payments/create` and `/api/payments/refunds`, caching the first successful attempt so rapid retries return the same response instead of initiating duplicate charges.
    - Captured UPI payments are guarded both at the service layer and with a database uniqueness constraint so a second PhonePe attempt for the same order returns a clear `UPI_PAYMENT_ALREADY_CAPTURED` error instead of racing a duplicate transaction.
    - PhonePe iframe checkouts now call `/api/payments/token-url`, which wraps the generic create-payment service to return the provider's PayPage URL and merchant transaction ID for the embedded `PhonePeCheckout.transact` flow.
+   - After PhonePe redirects the buyer back, the thank-you page first pings `/api/payments/phonepe/return` to log a "processing" event without touching order state, then begins polling `/api/payments/order-info/:orderId` so buyers see a "Processing" badge until the webhook settles the charge.
    - `/api/payments/order-info/:orderId` aggregates the order totals, shipping/tax breakdown, and the latest UPI identifiers (transaction id, UTR, VPA, receipt link) so the Thank-you and order history screens stay in sync with webhook-driven updates.
 
 6. **Shipping Charges**  


### PR DESCRIPTION
## Summary
- add a PhonePe return handler that validates redirect parameters, records a processing event, and replies without mutating orders
- gate the thank-you page status polling on the return probe so UPI buyers see a processing message until webhooks settle the payment
- extend the route and UI tests plus user-journey docs to cover the new reconciliation flow

## Testing
- npm run check
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbc6bd639c832a90b6d7f20e624ad7