### PR TITLE
Add migration for PhonePe polling jobs table

### DIFF
--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -43,6 +43,7 @@ Both refactors improved maintainability but did not change **endpoint URLs** or 
    - PhonePe iframe checkouts now call `/api/payments/token-url`, which wraps the generic create-payment service to return the provider's PayPage URL and merchant transaction ID for the embedded `PhonePeCheckout.transact` flow.
    - After PhonePe redirects the buyer back, the thank-you page first pings `/api/payments/phonepe/return` to log a "processing" event without touching order state, then begins polling `/api/payments/order-info/:orderId` so buyers see a "Processing" badge until the webhook settles the charge.
    - `/api/payments/order-info/:orderId` aggregates the order totals, shipping/tax breakdown, and the latest UPI identifiers (transaction id, UTR, VPA, receipt link) so the Thank-you and order history screens stay in sync with webhook-driven updates.
+   - A PhonePe polling worker persists mandated status-check intervals in the database, surfaces the next scheduled probe through `/api/payments/order-info/:orderId`, and stops automatically once the gateway returns a terminal state or the `expireAfter` deadline passes. This keeps reconciliation idempotent across restarts and lets the thank-you page show real-time progress messages.
 
 6. **Shipping Charges**  
    - Shipping calculation moved to `shippingRepository`.  

--- a/migrations/0005_phonepe_polling_jobs.sql
+++ b/migrations/0005_phonepe_polling_jobs.sql
@@ -1,0 +1,22 @@
+-- Create PhonePe polling jobs table to track reconciliation worker state
+CREATE TABLE IF NOT EXISTS phonepe_polling_jobs (
+  id varchar PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id varchar NOT NULL DEFAULT 'default',
+  order_id varchar NOT NULL REFERENCES orders(id),
+  payment_id varchar NOT NULL REFERENCES payments(id),
+  merchant_transaction_id varchar(255) NOT NULL,
+  status varchar(20) NOT NULL DEFAULT 'pending',
+  attempt integer NOT NULL DEFAULT 0,
+  next_poll_at timestamp NOT NULL,
+  expire_at timestamp NOT NULL,
+  last_polled_at timestamp,
+  last_status varchar(50),
+  last_response_code varchar(50),
+  last_error text,
+  completed_at timestamp,
+  created_at timestamp DEFAULT now(),
+  updated_at timestamp DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS phonepe_polling_payment_unique
+  ON phonepe_polling_jobs (tenant_id, payment_id);

--- a/server/adapters/phonepe-adapter.ts
+++ b/server/adapters/phonepe-adapter.ts
@@ -275,8 +275,9 @@ export class PhonePeAdapter implements PaymentsAdapter {
           providerTransactionId: response.data?.transactionId,
           providerReferenceId: merchantTransactionId,
           instrumentResponse: response.data?.instrumentResponse,
+          expireAfterSeconds: expireAfter,
         },
-        
+
         createdAt: new Date(),
       };
       

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,7 @@
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
+import { startPhonePePollingWorker } from "./services/phonepe-polling-registry";
 
 const app = express();
 app.use(express.json());
@@ -38,6 +39,7 @@ app.use((req, res, next) => {
 
 (async () => {
   const server = await registerRoutes(app);
+  await startPhonePePollingWorker();
 
   app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
     const status = err.status || err.statusCode || 500;

--- a/server/services/__tests__/phonepe-polling-worker.test.ts
+++ b/server/services/__tests__/phonepe-polling-worker.test.ts
@@ -1,0 +1,279 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  PhonePePollingWorker,
+  PHONEPE_POLL_INTERVALS_SECONDS,
+  type PhonePePollingJob,
+  type PhonePePollingPersistence,
+  type EnsureJobParams,
+} from "../phonepe-polling-worker";
+import type { PaymentResult } from "../../../shared/payment-types";
+
+class InMemoryPollingStore implements PhonePePollingPersistence {
+  private jobs = new Map<string, PhonePePollingJob>();
+  private idCounter = 1;
+
+  async listPendingJobs(): Promise<PhonePePollingJob[]> {
+    return Array.from(this.jobs.values()).filter((job) => job.status === "pending");
+  }
+
+  async ensureJob(params: EnsureJobParams): Promise<PhonePePollingJob> {
+    const existing = Array.from(this.jobs.values()).find(
+      (job) => job.paymentId === params.paymentId && job.tenantId === params.tenantId
+    );
+    if (existing) {
+      return existing;
+    }
+
+    const createdAt = params.createdAt ?? params.now;
+    const expireAt = new Date(createdAt.getTime() + params.expireAfterSeconds * 1000);
+    const delayMs = Math.min(
+      Math.max(0, Math.floor(params.initialIntervalSeconds)) * 1000,
+      Math.max(0, expireAt.getTime() - createdAt.getTime())
+    );
+    const nextPollAt = new Date(createdAt.getTime() + delayMs);
+
+    const job: PhonePePollingJob = {
+      id: `job-${this.idCounter++}`,
+      tenantId: params.tenantId,
+      orderId: params.orderId,
+      paymentId: params.paymentId,
+      merchantTransactionId: params.merchantTransactionId,
+      status: "pending",
+      attempt: 0,
+      nextPollAt,
+      expireAt,
+      lastPolledAt: undefined,
+      lastStatus: "created",
+      lastResponseCode: undefined,
+      lastError: undefined,
+      completedAt: undefined,
+      createdAt,
+      updatedAt: createdAt,
+    };
+
+    this.jobs.set(job.id, job);
+    return job;
+  }
+
+  async getJobById(id: string): Promise<PhonePePollingJob | null> {
+    return this.jobs.get(id) ?? null;
+  }
+
+  async recordPollingAttempt(
+    jobId: string,
+    update: {
+      attempt: number;
+      nextPollAt: Date;
+      polledAt: Date;
+      lastStatus: string;
+      lastResponseCode?: string;
+      lastError?: string | null;
+    }
+  ): Promise<PhonePePollingJob | null> {
+    const current = this.jobs.get(jobId);
+    if (!current) {
+      return null;
+    }
+
+    const next: PhonePePollingJob = {
+      ...current,
+      attempt: update.attempt,
+      nextPollAt: update.nextPollAt,
+      lastPolledAt: update.polledAt,
+      lastStatus: update.lastStatus,
+      lastResponseCode: update.lastResponseCode,
+      lastError: update.lastError ?? null,
+      updatedAt: new Date(update.polledAt),
+    };
+
+    this.jobs.set(jobId, next);
+    return next;
+  }
+
+  async markCompleted(
+    jobId: string,
+    finalStatus: "completed" | "failed",
+    update: {
+      polledAt: Date;
+      lastStatus: string;
+      lastResponseCode?: string;
+      lastError?: string | null;
+      attempt: number;
+    }
+  ): Promise<PhonePePollingJob | null> {
+    const current = this.jobs.get(jobId);
+    if (!current) {
+      return null;
+    }
+
+    const next: PhonePePollingJob = {
+      ...current,
+      status: finalStatus,
+      lastPolledAt: update.polledAt,
+      lastStatus: update.lastStatus,
+      lastResponseCode: update.lastResponseCode,
+      lastError: update.lastError ?? null,
+      completedAt: update.polledAt,
+      attempt: update.attempt,
+      updatedAt: new Date(update.polledAt),
+    };
+
+    this.jobs.set(jobId, next);
+    return next;
+  }
+
+  async markExpired(
+    jobId: string,
+    update: {
+      polledAt: Date;
+      lastStatus?: string;
+      lastError?: string | null;
+      attempt: number;
+    }
+  ): Promise<PhonePePollingJob | null> {
+    const current = this.jobs.get(jobId);
+    if (!current) {
+      return null;
+    }
+
+    const next: PhonePePollingJob = {
+      ...current,
+      status: "expired",
+      lastPolledAt: update.polledAt,
+      lastStatus: update.lastStatus ?? current.lastStatus,
+      lastError: update.lastError ?? null,
+      completedAt: update.polledAt,
+      attempt: update.attempt,
+      updatedAt: new Date(update.polledAt),
+    };
+
+    this.jobs.set(jobId, next);
+    return next;
+  }
+
+  getJobSnapshot(id: string): PhonePePollingJob | undefined {
+    return this.jobs.get(id);
+  }
+}
+
+describe("PhonePePollingWorker", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const buildPaymentResult = (status: string): PaymentResult => ({
+    paymentId: "pay-1",
+    status: status as PaymentResult["status"],
+    amount: 1000,
+    currency: "INR",
+    provider: "phonepe",
+    environment: "test",
+    providerData: { responseCode: status.toUpperCase() },
+    createdAt: new Date(),
+  });
+
+  it("polls pending payments until completion using mandated intervals", async () => {
+    const store = new InMemoryPollingStore();
+    const statuses = ["created", "processing", "captured"];
+    const verifyPayment = vi.fn().mockImplementation(async () => buildPaymentResult(statuses.shift()!));
+
+    const worker = new PhonePePollingWorker({
+      store,
+      getVerificationService: () => ({ verifyPayment }),
+      now: () => new Date(Date.now()),
+    });
+
+    await worker.start();
+    const job = await worker.registerJob({
+      tenantId: "default",
+      orderId: "order-1",
+      paymentId: "pay-1",
+      merchantTransactionId: "mt-1",
+      expireAfterSeconds: 900,
+      createdAt: new Date(Date.now()),
+    });
+
+    expect(verifyPayment).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(PHONEPE_POLL_INTERVALS_SECONDS[0] * 1000);
+    expect(verifyPayment).toHaveBeenCalledTimes(1);
+    const afterFirstPoll = store.getJobSnapshot(job.id)!;
+    expect(afterFirstPoll.attempt).toBe(1);
+    expect(afterFirstPoll.nextPollAt.getTime()).toBe(Date.now() + PHONEPE_POLL_INTERVALS_SECONDS[1] * 1000);
+
+    await worker.registerJob({
+      tenantId: "default",
+      orderId: "order-1",
+      paymentId: "pay-1",
+      merchantTransactionId: "mt-1",
+      expireAfterSeconds: 900,
+      createdAt: new Date(Date.now()),
+    });
+    expect(store.getJobSnapshot(job.id)?.attempt).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(PHONEPE_POLL_INTERVALS_SECONDS[1] * 1000);
+    expect(verifyPayment).toHaveBeenCalledTimes(2);
+    const afterSecondPoll = store.getJobSnapshot(job.id)!;
+    expect(afterSecondPoll.attempt).toBe(2);
+
+    await vi.advanceTimersByTimeAsync(PHONEPE_POLL_INTERVALS_SECONDS[2] * 1000);
+    expect(verifyPayment).toHaveBeenCalledTimes(3);
+    const completedJob = store.getJobSnapshot(job.id)!;
+    expect(completedJob.status).toBe("completed");
+
+    await vi.advanceTimersByTimeAsync(PHONEPE_POLL_INTERVALS_SECONDS[3] * 1000);
+    expect(verifyPayment).toHaveBeenCalledTimes(3);
+
+    worker.stop();
+  });
+
+  it("marks jobs as failed when PhonePe reports failure", async () => {
+    const store = new InMemoryPollingStore();
+    const statuses = ["created", "failed"];
+    const verifyPayment = vi.fn().mockImplementation(async () => buildPaymentResult(statuses.shift()!));
+
+    const worker = new PhonePePollingWorker({
+      store,
+      getVerificationService: () => ({ verifyPayment }),
+      now: () => new Date(Date.now()),
+    });
+
+    await worker.start();
+    const job = await worker.registerJob({
+      tenantId: "default",
+      orderId: "order-2",
+      paymentId: "pay-2",
+      merchantTransactionId: "mt-2",
+      expireAfterSeconds: 900,
+      createdAt: new Date(Date.now()),
+    });
+
+    await vi.advanceTimersByTimeAsync(PHONEPE_POLL_INTERVALS_SECONDS[0] * 1000);
+    expect(verifyPayment).toHaveBeenCalledTimes(1);
+
+    await worker.registerJob({
+      tenantId: "default",
+      orderId: "order-2",
+      paymentId: "pay-2",
+      merchantTransactionId: "mt-2",
+      expireAfterSeconds: 900,
+      createdAt: new Date(Date.now()),
+    });
+
+    await vi.advanceTimersByTimeAsync(PHONEPE_POLL_INTERVALS_SECONDS[1] * 1000);
+    expect(verifyPayment).toHaveBeenCalledTimes(2);
+    const failedJob = store.getJobSnapshot(job.id)!;
+    expect(failedJob.status).toBe("failed");
+    expect(failedJob.attempt).toBe(2);
+
+    await vi.advanceTimersByTimeAsync(PHONEPE_POLL_INTERVALS_SECONDS[2] * 1000);
+    expect(verifyPayment).toHaveBeenCalledTimes(2);
+
+    worker.stop();
+  });
+});

--- a/server/services/phonepe-polling-registry.ts
+++ b/server/services/phonepe-polling-registry.ts
@@ -1,0 +1,15 @@
+import type { Environment } from "../../shared/payment-providers";
+import { createPaymentsService } from "./payments-service";
+import { phonePePollingStore } from "../storage";
+import { PhonePePollingWorker } from "./phonepe-polling-worker";
+
+const environment: Environment = (process.env.NODE_ENV === "production" ? "live" : "test") as Environment;
+
+export const phonePePollingWorker = new PhonePePollingWorker({
+  store: phonePePollingStore,
+  getVerificationService: () => createPaymentsService({ environment }),
+});
+
+export const startPhonePePollingWorker = async (): Promise<void> => {
+  await phonePePollingWorker.start();
+};

--- a/server/services/phonepe-polling-worker.ts
+++ b/server/services/phonepe-polling-worker.ts
@@ -1,0 +1,335 @@
+import type { VerifyPaymentParams, PaymentResult } from "../../shared/payment-types";
+
+export type PhonePePollingFinalStatus = "pending" | "completed" | "failed" | "expired";
+
+export interface PhonePePollingJob {
+  id: string;
+  tenantId: string;
+  orderId: string;
+  paymentId: string;
+  merchantTransactionId: string;
+  status: PhonePePollingFinalStatus;
+  attempt: number;
+  nextPollAt: Date;
+  expireAt: Date;
+  lastPolledAt?: Date | null;
+  lastStatus?: string | null;
+  lastResponseCode?: string | null;
+  lastError?: string | null;
+  completedAt?: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface CreatePhonePePollingJobInput {
+  tenantId: string;
+  orderId: string;
+  paymentId: string;
+  merchantTransactionId: string;
+  expireAfterSeconds: number;
+  createdAt?: Date;
+}
+
+export interface EnsureJobParams extends CreatePhonePePollingJobInput {
+  initialIntervalSeconds: number;
+  now: Date;
+}
+
+export interface PhonePePollingPersistence {
+  listPendingJobs(): Promise<PhonePePollingJob[]>;
+  ensureJob(params: EnsureJobParams): Promise<PhonePePollingJob>;
+  getJobById(id: string): Promise<PhonePePollingJob | null>;
+  recordPollingAttempt(
+    jobId: string,
+    update: {
+      attempt: number;
+      nextPollAt: Date;
+      polledAt: Date;
+      lastStatus: string;
+      lastResponseCode?: string;
+      lastError?: string | null;
+    }
+  ): Promise<PhonePePollingJob | null>;
+  markCompleted(
+    jobId: string,
+    finalStatus: "completed" | "failed",
+    update: {
+      polledAt: Date;
+      lastStatus: string;
+      lastResponseCode?: string;
+      lastError?: string | null;
+      attempt: number;
+    }
+  ): Promise<PhonePePollingJob | null>;
+  markExpired(
+    jobId: string,
+    update: {
+      polledAt: Date;
+      lastStatus?: string;
+      lastError?: string | null;
+      attempt: number;
+    }
+  ): Promise<PhonePePollingJob | null>;
+}
+
+export interface PhonePeVerificationService {
+  verifyPayment(params: VerifyPaymentParams, tenantId: string): Promise<PaymentResult>;
+}
+
+type WorkerLogger = {
+  debug: (...args: unknown[]) => void;
+  info: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+};
+
+export interface PhonePePollingWorkerOptions {
+  store: PhonePePollingPersistence;
+  getVerificationService: () => PhonePeVerificationService;
+  pollIntervalsSeconds?: readonly number[];
+  now?: () => Date;
+  logger?: Partial<WorkerLogger>;
+}
+
+export const PHONEPE_POLL_INTERVALS_SECONDS = Object.freeze([15, 30, 60, 120, 240]);
+
+const TERMINAL_SUCCESS_STATUSES = new Set([
+  "captured",
+  "completed",
+  "paid",
+  "succeeded",
+  "success",
+]);
+
+const TERMINAL_FAILURE_STATUSES = new Set([
+  "failed",
+  "cancelled",
+  "canceled",
+  "timedout",
+  "expired",
+]);
+
+const DEFAULT_LOGGER: WorkerLogger = {
+  debug: (..._args: unknown[]) => {},
+  info: (..._args: unknown[]) => {},
+  warn: (..._args: unknown[]) => {},
+  error: (..._args: unknown[]) => {},
+};
+
+export class PhonePePollingWorker {
+  private readonly store: PhonePePollingPersistence;
+  private readonly getVerificationService: () => PhonePeVerificationService;
+  private readonly pollIntervals: readonly number[];
+  private readonly now: () => Date;
+  private readonly logger: WorkerLogger;
+
+  private running = false;
+  private readonly timers = new Map<string, NodeJS.Timeout>();
+
+  constructor(options: PhonePePollingWorkerOptions) {
+    this.store = options.store;
+    this.getVerificationService = options.getVerificationService;
+    this.pollIntervals = options.pollIntervalsSeconds ?? PHONEPE_POLL_INTERVALS_SECONDS;
+    this.now = options.now ?? (() => new Date());
+    this.logger = { ...DEFAULT_LOGGER, ...(options.logger ?? {}) };
+  }
+
+  public async start(): Promise<void> {
+    if (this.running) {
+      return;
+    }
+
+    this.running = true;
+    this.logger.debug("phonepe-polling-worker:start");
+
+    const jobs = await this.store.listPendingJobs();
+    for (const job of jobs) {
+      if (job.status === "pending") {
+        this.schedule(job);
+      }
+    }
+  }
+
+  public stop(): void {
+    this.logger.debug("phonepe-polling-worker:stop");
+    this.running = false;
+    this.timers.forEach((timeout) => {
+      clearTimeout(timeout);
+    });
+    this.timers.clear();
+  }
+
+  public async registerJob(params: CreatePhonePePollingJobInput): Promise<PhonePePollingJob> {
+    const now = this.now();
+    const job = await this.store.ensureJob({
+      ...params,
+      initialIntervalSeconds: this.resolveIntervalForAttempt(0),
+      now,
+    });
+
+    if (this.running && job.status === "pending") {
+      this.schedule(job);
+    }
+
+    return job;
+  }
+
+  private schedule(job: PhonePePollingJob): void {
+    if (!this.running) {
+      return;
+    }
+
+    this.clearTimer(job.id);
+    const now = this.now();
+    const delay = Math.max(0, job.nextPollAt.getTime() - now.getTime());
+
+    const timeout = setTimeout(() => {
+      this.processJob(job.id).catch((error) => {
+        this.logger.error("phonepe-polling-worker:process-error", error);
+      });
+    }, delay);
+
+    this.timers.set(job.id, timeout);
+  }
+
+  private clearTimer(jobId: string): void {
+    const existing = this.timers.get(jobId);
+    if (existing) {
+      clearTimeout(existing);
+      this.timers.delete(jobId);
+    }
+  }
+
+  private async processJob(jobId: string): Promise<void> {
+    this.clearTimer(jobId);
+
+    const job = await this.store.getJobById(jobId);
+    if (!job || job.status !== "pending") {
+      return;
+    }
+
+    const now = this.now();
+    if (job.expireAt.getTime() <= now.getTime()) {
+      await this.store.markExpired(job.id, {
+        polledAt: now,
+        lastStatus: job.lastStatus ?? "expired",
+        lastError: job.lastError,
+        attempt: job.attempt,
+      });
+      return;
+    }
+
+    try {
+      const verificationService = this.getVerificationService();
+      const result = await verificationService.verifyPayment(
+        {
+          paymentId: job.paymentId,
+          providerData: { merchantTransactionId: job.merchantTransactionId },
+        },
+        job.tenantId
+      );
+
+      const normalizedStatus = (result.status || "").toLowerCase();
+      const responseCode = typeof result.providerData?.responseCode === "string"
+        ? result.providerData.responseCode
+        : undefined;
+
+      if (TERMINAL_SUCCESS_STATUSES.has(normalizedStatus)) {
+        await this.store.markCompleted(job.id, "completed", {
+          polledAt: now,
+          lastStatus: normalizedStatus,
+          lastResponseCode: responseCode,
+          lastError: null,
+          attempt: job.attempt + 1,
+        });
+        return;
+      }
+
+      if (TERMINAL_FAILURE_STATUSES.has(normalizedStatus)) {
+        await this.store.markCompleted(job.id, "failed", {
+          polledAt: now,
+          lastStatus: normalizedStatus,
+          lastResponseCode: responseCode,
+          lastError: result.error?.message ?? null,
+          attempt: job.attempt + 1,
+        });
+        return;
+      }
+
+      await this.scheduleNextAttempt(job, now, {
+        lastStatus: normalizedStatus || job.lastStatus || "processing",
+        lastResponseCode: responseCode,
+        lastError: null,
+      });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      await this.scheduleNextAttempt(job, now, {
+        lastStatus: job.lastStatus ?? "processing",
+        lastResponseCode: job.lastResponseCode ?? undefined,
+        lastError: errorMessage,
+      });
+    }
+  }
+
+  private async scheduleNextAttempt(
+    job: PhonePePollingJob,
+    now: Date,
+    context: {
+      lastStatus: string;
+      lastResponseCode?: string;
+      lastError?: string | null;
+    }
+  ): Promise<void> {
+    const nextAttempt = job.attempt + 1;
+    const intervalSeconds = this.resolveIntervalForAttempt(nextAttempt);
+    const timeUntilExpiryMs = job.expireAt.getTime() - now.getTime();
+
+    if (timeUntilExpiryMs <= 0) {
+      await this.store.markExpired(job.id, {
+        polledAt: now,
+        lastStatus: context.lastStatus,
+        lastError: context.lastError,
+        attempt: job.attempt + 1,
+      });
+      return;
+    }
+
+    const delayMs = Math.min(intervalSeconds * 1000, timeUntilExpiryMs);
+    if (delayMs <= 0) {
+      await this.store.markExpired(job.id, {
+        polledAt: now,
+        lastStatus: context.lastStatus,
+        lastError: context.lastError,
+        attempt: job.attempt + 1,
+      });
+      return;
+    }
+
+    const nextPollAt = new Date(now.getTime() + delayMs);
+    const updated = await this.store.recordPollingAttempt(job.id, {
+      attempt: nextAttempt,
+      nextPollAt,
+      polledAt: now,
+      lastStatus: context.lastStatus,
+      lastResponseCode: context.lastResponseCode,
+      lastError: context.lastError ?? null,
+    });
+
+    if (updated && updated.status === "pending" && this.running) {
+      this.schedule(updated);
+    }
+  }
+
+  private resolveIntervalForAttempt(attempt: number): number {
+    if (attempt < 0) {
+      return this.pollIntervals[0] ?? 15;
+    }
+
+    if (attempt >= this.pollIntervals.length) {
+      return this.pollIntervals[this.pollIntervals.length - 1] ?? 15;
+    }
+
+    const interval = this.pollIntervals[attempt];
+    return Number.isFinite(interval) && interval > 0 ? interval : this.pollIntervals[0] ?? 15;
+  }
+}

--- a/server/storage/index.ts
+++ b/server/storage/index.ts
@@ -4,6 +4,7 @@ import { OffersRepository } from "./offers";
 import { OrdersRepository } from "./orders";
 import { SettingsRepository } from "./settings";
 import { ShippingRepository } from "./shipping";
+import { phonePePollingStore, PhonePePollingStore } from "./phonepe-polling";
 // import { PaymentsRepository } from "./payments"; // Temporarily commented during payment system refactor
 
 export const settingsRepository = new SettingsRepository();
@@ -12,6 +13,7 @@ export const productsRepository = new ProductsRepository();
 export const offersRepository = new OffersRepository();
 export const ordersRepository = new OrdersRepository();
 export const shippingRepository = new ShippingRepository(settingsRepository);
+export { phonePePollingStore };
 // export const paymentsRepository = new PaymentsRepository(); // Temporarily commented during payment system refactor
 
 export type {
@@ -21,5 +23,6 @@ export type {
   OrdersRepository,
   SettingsRepository,
   ShippingRepository,
+  PhonePePollingStore,
   // PaymentsRepository, // Temporarily commented during payment system refactor
 };

--- a/server/storage/phonepe-polling.ts
+++ b/server/storage/phonepe-polling.ts
@@ -1,0 +1,194 @@
+import { and, desc, eq } from "drizzle-orm";
+import { db } from "../db";
+import { phonepePollingJobs } from "../../shared/schema";
+import type {
+  EnsureJobParams,
+  PhonePePollingJob,
+  PhonePePollingPersistence,
+} from "../services/phonepe-polling-worker";
+
+function toJob(record: typeof phonepePollingJobs.$inferSelect | undefined | null): PhonePePollingJob | null {
+  if (!record) {
+    return null;
+  }
+
+  return {
+    ...record,
+    status: record.status as PhonePePollingJob["status"],
+    lastPolledAt: record.lastPolledAt ?? undefined,
+    lastStatus: record.lastStatus ?? undefined,
+    lastResponseCode: record.lastResponseCode ?? undefined,
+    lastError: record.lastError ?? undefined,
+    completedAt: record.completedAt ?? undefined,
+    createdAt: record.createdAt ?? new Date(),
+    updatedAt: record.updatedAt ?? new Date(),
+  };
+}
+
+export class PhonePePollingStore implements PhonePePollingPersistence {
+  public async listPendingJobs(): Promise<PhonePePollingJob[]> {
+    const rows = await db
+      .select()
+      .from(phonepePollingJobs)
+      .where(eq(phonepePollingJobs.status, "pending"));
+
+    return rows.map((row) => toJob(row)!) as PhonePePollingJob[];
+  }
+
+  public async ensureJob(params: EnsureJobParams): Promise<PhonePePollingJob> {
+    const createdAt = params.createdAt ?? params.now;
+    const expireSeconds = Number.isFinite(params.expireAfterSeconds)
+      ? Math.max(0, Math.floor(params.expireAfterSeconds))
+      : 0;
+    const expireAt = new Date(createdAt.getTime() + expireSeconds * 1000);
+    const firstIntervalMs = Math.max(0, Math.floor(params.initialIntervalSeconds)) * 1000;
+    const timeUntilExpiry = Math.max(0, expireAt.getTime() - createdAt.getTime());
+    const initialDelay = Math.min(firstIntervalMs, timeUntilExpiry);
+    const nextPollAt = new Date(createdAt.getTime() + initialDelay);
+
+    const job = await db.transaction(async (trx) => {
+      const existing = await trx.query.phonepePollingJobs.findFirst({
+        where: and(
+          eq(phonepePollingJobs.tenantId, params.tenantId),
+          eq(phonepePollingJobs.paymentId, params.paymentId)
+        ),
+      });
+
+      if (existing) {
+        return existing;
+      }
+
+      const [inserted] = await trx
+        .insert(phonepePollingJobs)
+        .values({
+          tenantId: params.tenantId,
+          orderId: params.orderId,
+          paymentId: params.paymentId,
+          merchantTransactionId: params.merchantTransactionId,
+          status: "pending",
+          attempt: 0,
+          nextPollAt,
+          expireAt,
+          lastStatus: "created",
+          createdAt,
+          updatedAt: createdAt,
+        })
+        .returning();
+
+      return inserted;
+    });
+
+    return toJob(job)!;
+  }
+
+  public async getJobById(id: string): Promise<PhonePePollingJob | null> {
+    const record = await db.query.phonepePollingJobs.findFirst({
+      where: eq(phonepePollingJobs.id, id),
+    });
+
+    return toJob(record);
+  }
+
+  public async recordPollingAttempt(
+    jobId: string,
+    update: {
+      attempt: number;
+      nextPollAt: Date;
+      polledAt: Date;
+      lastStatus: string;
+      lastResponseCode?: string;
+      lastError?: string | null;
+    }
+  ): Promise<PhonePePollingJob | null> {
+    const [record] = await db
+      .update(phonepePollingJobs)
+      .set({
+        attempt: update.attempt,
+        nextPollAt: update.nextPollAt,
+        lastPolledAt: update.polledAt,
+        lastStatus: update.lastStatus,
+        lastResponseCode: update.lastResponseCode ?? null,
+        lastError: update.lastError ?? null,
+        updatedAt: new Date(),
+      })
+      .where(eq(phonepePollingJobs.id, jobId))
+      .returning();
+
+    return toJob(record);
+  }
+
+  public async markCompleted(
+    jobId: string,
+    finalStatus: "completed" | "failed",
+    update: {
+      polledAt: Date;
+      lastStatus: string;
+      lastResponseCode?: string;
+      lastError?: string | null;
+      attempt: number;
+    }
+  ): Promise<PhonePePollingJob | null> {
+    const [record] = await db
+      .update(phonepePollingJobs)
+      .set({
+        status: finalStatus,
+        lastPolledAt: update.polledAt,
+        lastStatus: update.lastStatus,
+        lastResponseCode: update.lastResponseCode ?? null,
+        lastError: update.lastError ?? null,
+        completedAt: update.polledAt,
+        attempt: update.attempt,
+        updatedAt: new Date(),
+      })
+      .where(eq(phonepePollingJobs.id, jobId))
+      .returning();
+
+    return toJob(record);
+  }
+
+  public async markExpired(
+    jobId: string,
+    update: {
+      polledAt: Date;
+      lastStatus?: string;
+      lastError?: string | null;
+      attempt: number;
+    }
+  ): Promise<PhonePePollingJob | null> {
+    const [record] = await db
+      .update(phonepePollingJobs)
+      .set({
+        status: "expired",
+        lastPolledAt: update.polledAt,
+        lastStatus: update.lastStatus ?? "expired",
+        lastError: update.lastError ?? null,
+        completedAt: update.polledAt,
+        attempt: update.attempt,
+        updatedAt: new Date(),
+      })
+      .where(eq(phonepePollingJobs.id, jobId))
+      .returning();
+
+    return toJob(record);
+  }
+
+  public async getLatestJobForOrder(orderId: string, tenantId: string): Promise<PhonePePollingJob | null> {
+    const [record] = await db
+      .select()
+      .from(phonepePollingJobs)
+      .where(
+        and(
+          eq(phonepePollingJobs.orderId, orderId),
+          eq(phonepePollingJobs.tenantId, tenantId)
+        )
+      )
+      .orderBy(desc(phonepePollingJobs.createdAt))
+      .limit(1);
+
+    return toJob(record ?? null);
+  }
+}
+
+export const phonePePollingStore = new PhonePePollingStore();
+
+export type { PhonePePollingJob };


### PR DESCRIPTION
## Summary
- add the phonepe_polling_jobs table to the SQL migrations so the new worker persistence exists in production
- enforce the unique tenant/payment constraint to match the Drizzle schema

## Testing
- npm run check
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dbd25c0500832aa21986ddae2ae0eb