### PR TITLE
Enforce forward payment status transitions

### DIFF
--- a/server/services/__tests__/payments-service.test.ts
+++ b/server/services/__tests__/payments-service.test.ts
@@ -1,5 +1,5 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import type { PaymentResult } from "../../../shared/payment-types";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PaymentEvent, PaymentResult } from "../../../shared/payment-types";
 
 process.env.DATABASE_URL ??= "postgres://user:pass@localhost:5432/test";
 
@@ -18,12 +18,14 @@ const insertValuesMock = vi.fn(async (values: any) => {
   paymentInserts.push(values);
 });
 
-const transactionMock = vi.fn(async (callback: (trx: any) => Promise<void>) => {
+const defaultTransactionImplementation = async (callback: (trx: any) => Promise<void>) => {
   await callback({
     insert: vi.fn(() => ({ values: insertValuesMock })),
     update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn() })) })),
   });
-});
+};
+
+const transactionMock = vi.fn(defaultTransactionImplementation);
 
 vi.mock("../../db", () => ({
   db: {
@@ -74,6 +76,7 @@ describe("PaymentsService.createPayment", () => {
     paymentInserts.length = 0;
     insertValuesMock.mockClear();
     transactionMock.mockClear();
+    transactionMock.mockImplementation(defaultTransactionImplementation);
     selectMock.mockClear();
     adapter.createPayment.mockReset();
     executeWithIdempotencyMock.mockReset();
@@ -173,5 +176,140 @@ describe("PaymentsService.createPayment", () => {
     ).rejects.toMatchObject({ code: "UPI_PAYMENT_ALREADY_CAPTURED" });
 
     expect(adapter.createPayment).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("PaymentsService.updateStoredPayment lifecycle", () => {
+  const baseResult: PaymentResult = {
+    paymentId: "pay_1",
+    status: "created",
+    amount: 1000,
+    currency: "INR",
+    provider: "phonepe",
+    environment: "test",
+    providerData: {},
+    createdAt: new Date(),
+  };
+
+  const baseEvent: PaymentEvent = {
+    id: "evt_1",
+    paymentId: "pay_1",
+    tenantId: "default",
+    provider: "phonepe",
+    environment: "test" as const,
+    type: "payment_verified",
+    data: {},
+    timestamp: new Date(),
+    source: "api" as const,
+  };
+
+  beforeEach(() => {
+    transactionMock.mockClear();
+    transactionMock.mockImplementation(defaultTransactionImplementation);
+    (PaymentsServiceClass as unknown as { instances: Map<string, any> }).instances = new Map();
+  });
+
+  afterEach(() => {
+    transactionMock.mockImplementation(defaultTransactionImplementation);
+  });
+
+  it("skips updates when the lifecycle would move backwards", async () => {
+    const updateSpy = vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn() })) }));
+    const eventInsertSpy = vi.fn();
+    const selectSpy = vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(async () => [
+            { orderId: "ord_1", currentStatus: "captured" },
+          ]),
+        })),
+      })),
+    }));
+
+    transactionMock.mockImplementation(async (callback) => {
+      await callback({
+        select: selectSpy,
+        update: updateSpy,
+        insert: vi.fn(() => ({ values: eventInsertSpy })),
+      });
+    });
+
+    const service = createPaymentsService({ environment: "test" });
+
+    await (service as any).updateStoredPayment(
+      { ...baseResult, status: "processing" },
+      "default",
+      { ...baseEvent, status: "processing" }
+    );
+
+    expect(selectSpy).toHaveBeenCalled();
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(eventInsertSpy).not.toHaveBeenCalled();
+  });
+
+  it("promotes the order only when a verified completed result is processed", async () => {
+    const updateSpy = vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn() })) }));
+    const eventInsertSpy = vi.fn();
+    const selectSpy = vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(async () => [
+            { orderId: "ord_1", currentStatus: "processing" },
+          ]),
+        })),
+      })),
+    }));
+
+    transactionMock.mockImplementation(async (callback) => {
+      await callback({
+        select: selectSpy,
+        update: updateSpy,
+        insert: vi.fn(() => ({ values: eventInsertSpy })),
+      });
+    });
+
+    const service = createPaymentsService({ environment: "test" });
+
+    await (service as any).updateStoredPayment(
+      { ...baseResult, status: "captured" },
+      "default",
+      { ...baseEvent, type: "payment_verified", status: "captured" }
+    );
+
+    expect(updateSpy).toHaveBeenCalledTimes(2);
+    expect(eventInsertSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not promote the order when the completed status is not verified", async () => {
+    const updateSpy = vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn() })) }));
+    const eventInsertSpy = vi.fn();
+    const selectSpy = vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(async () => [
+            { orderId: "ord_1", currentStatus: "processing" },
+          ]),
+        })),
+      })),
+    }));
+
+    transactionMock.mockImplementation(async (callback) => {
+      await callback({
+        select: selectSpy,
+        update: updateSpy,
+        insert: vi.fn(() => ({ values: eventInsertSpy })),
+      });
+    });
+
+    const service = createPaymentsService({ environment: "test" });
+
+    await (service as any).updateStoredPayment(
+      { ...baseResult, status: "captured" },
+      "default",
+      { ...baseEvent, type: "payment_captured", status: "captured" }
+    );
+
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    expect(eventInsertSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/server/services/__tests__/phonepe-flows.test.ts
+++ b/server/services/__tests__/phonepe-flows.test.ts
@@ -411,11 +411,11 @@ describe("PhonePe callback/webhook ordering", () => {
     updateRowCounts.push(1, 0);
     adapter.verifyPayment.mockResolvedValue(phonePeImmediateCapture);
 
+    const orderUpdatesBefore = updateCalls.filter((call) => call.table === orders).length;
     await service.verifyPayment({ paymentId: "pay_test_123" }, "default");
 
     const orderUpdates = updateCalls.filter((call) => call.table === orders);
-    const latestOrderUpdate = orderUpdates.at(-1);
-    expect(latestOrderUpdate?.rowCount).toBe(0);
+    expect(orderUpdates.length).toBe(orderUpdatesBefore);
   });
 });
 

--- a/server/services/payments-service.ts
+++ b/server/services/payments-service.ts
@@ -691,8 +691,16 @@ export class PaymentsService {
 
       const currentLifecycle = PaymentsService.normalizeLifecycleStatus(existingPayment.currentStatus);
       const nextLifecycle = PaymentsService.normalizeLifecycleStatus(result.status);
+      const isSameLifecycle = currentLifecycle === nextLifecycle;
+      const allowVerifiedCompletionReplay =
+        isSameLifecycle &&
+        nextLifecycle === 'completed' &&
+        event.type === 'payment_verified';
 
-      if (!PaymentsService.canTransitionLifecycleStatus(currentLifecycle, nextLifecycle)) {
+      if (
+        !PaymentsService.canTransitionLifecycleStatus(currentLifecycle, nextLifecycle) &&
+        !allowVerifiedCompletionReplay
+      ) {
         return;
       }
 

--- a/server/services/webhook-router.ts
+++ b/server/services/webhook-router.ts
@@ -363,8 +363,16 @@ export class WebhookRouter {
 
         const currentLifecycle = this.toLifecycleStatus(paymentRecord.currentStatus);
         const nextLifecycle = this.toLifecycleStatus(normalizedStatus);
+        const isSameLifecycle = currentLifecycle === nextLifecycle;
+        const allowVerifiedCompletionReplay =
+          isSameLifecycle &&
+          nextLifecycle === 'completed' &&
+          options?.verified === true;
 
-        if (!this.canTransitionLifecycleStatus(currentLifecycle, nextLifecycle)) {
+        if (
+          !this.canTransitionLifecycleStatus(currentLifecycle, nextLifecycle) &&
+          !allowVerifiedCompletionReplay
+        ) {
           return false;
         }
 


### PR DESCRIPTION
## Summary
- prevent backwards lifecycle changes in the payments service while only promoting orders on verified completed results
- gate webhook payment updates with the same lifecycle checks and verified flag to short-circuit replays
- add unit tests covering blocked regressions for service and webhook flows

## Testing
- npm run check
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbd6cd1e68832a9d3ca90bdb9b2cc6