### PR TITLE
Add PhonePe host selection and sandbox fixtures

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,5 @@
+{
+  "MD013": false,
+  "MD022": false,
+  "MD032": false
+}

--- a/README.md
+++ b/README.md
@@ -28,3 +28,28 @@ These variables must be provided by any container platform so the application ca
 - (Optional) `TWOFACTOR_API_KEY` – required if integrating with the external 2Factor OTP provider.
 
 Set `PORT` if your platform requires a specific port binding; otherwise the container defaults to `5000`.
+
+## PhonePe Sandbox & Simulator
+
+The PhonePe integration ships with default sandbox and production hosts so new environments work without populating custom URL secrets:
+
+- **Sandbox (UAT)** – `https://api-preprod.phonepe.com/apis/pgsandbox`
+- **Production** – `https://api.phonepe.com/apis/hermes`
+
+The unified `PhonePeConfig` merges these defaults with any `PAYAPP_*_PHONEPE_HOST_UAT` / `HOST_PROD` overrides and exposes an optional `activeHost` selector:
+
+- Set `PAYAPP_TEST_PHONEPE_HOST_ACTIVE=uat` (or `prod`/a fully qualified URL) when you want to pin an environment to a specific host without editing database metadata.
+- Alternatively store `{ "phonepeHost": "prod" }` (or a URL) inside the `payment_provider_config.metadata` column to toggle hosts at runtime. Metadata wins over environment configuration, and omitting a value falls back to the default host for the current environment.
+
+When exercising the PhonePe sandbox, the gateway simulator recognizes dedicated VPAs:
+
+- `success@ybl` – completes immediately with a `COMPLETED` state.
+- `failed@ybl` – triggers a `FAILED` response (`UPI_TXN_FAILED`).
+- `pending@ybl` – remains in `PENDING` until a follow-up callback/status check resolves it.
+- Dynamic QR journeys return pending QR payloads first and settle to `COMPLETED` when the buyer scans with a success handle.
+
+Example simulator payloads that cover those flows live in [`server/services/__tests__/__fixtures__/phonepe-sandbox/`](server/services/__tests__/__fixtures__/phonepe-sandbox/index.ts).
+
+### Documentation linting
+
+Run `npm run lint:md` to lint Markdown guides (README + `docs/**/*.md`) with Markdownlint so configuration drift is caught during CI or local checks.

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -80,6 +80,7 @@ Both refactors improved maintainability but did not change **endpoint URLs** or 
    - Webhook ingestion now auto-detects the correct provider across all enabled configs per tenant, deduplicates payloads with event/transaction identifiers, and rejects invalid signatures with audit logs so replay attempts are acknowledged without mutating state.
    - PhonePe now sources its client credentials (`client_id`, `client_secret`, `client_version`), webhook basic-auth pair, redirect URL, and API hosts from the PAYAPP_* secret bundle while keeping the merchant ID in admin-managed database config, preventing drift between environments.
    - PhonePe API traffic now reuses a shared OAuth token manager that refreshes access tokens a few minutes before expiry and retries once on authentication failures, ensuring checkout, refund, and status checks remain seamless for buyers and support staff even during sustained traffic.
+   - Host switching, sandbox VPAs, and simulator fixtures are documented in the [PhonePe Sandbox & Simulator guide](../README.md#phonepe-sandbox--simulator).
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -110,6 +110,7 @@
         "drizzle-kit": "^0.30.4",
         "esbuild": "^0.25.0",
         "jsdom": "^27.0.0",
+        "markdownlint-cli": "^0.45.0",
         "postcss": "^8.4.47",
         "tailwindcss": "^3.4.17",
         "tsx": "^4.19.1",
@@ -2548,6 +2549,29 @@
       "integrity": "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==",
       "peerDependencies": {
         "react-hook-form": "^7.0.0"
+      }
+    },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -5609,6 +5633,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/katex": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.7.tgz",
+      "integrity": "sha512-HMwFiRujE5PjrgwHQ25+bsLJgowjGjm5Z8FVSf0N6PwgJrwxH0QxzHYDcKsTfV3wva0vzrpqMTJS2jXPr5BMEQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -6362,6 +6393,13 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/aria-hidden": {
       "version": "1.2.4",
@@ -7313,6 +7351,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/define-data-property": {
@@ -8658,12 +8706,12 @@
       "license": "MIT"
     },
     "node_modules/foreground-child": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
-      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
       "license": "ISC",
       "dependencies": {
-        "cross-spawn": "^7.0.0",
+        "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
       },
       "engines": {
@@ -9194,6 +9242,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -9209,6 +9267,16 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
+      "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/inline-style-parser": {
       "version": "0.2.4",
@@ -9462,6 +9530,19 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/jsdom": {
       "version": "27.0.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.0.tgz",
@@ -9588,6 +9669,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/jwa": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
@@ -9607,6 +9705,33 @@
       "dependencies": {
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.16.22",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.22.tgz",
+      "integrity": "sha512-XCHRdUw4lf3SKBaJe4EvgqIuWwkPSo9XoeO8GjQW94Bp7TWv9hNhzZjZ+OH9yf1UmLygb7DIT5GSFQiyt16zYg==",
+      "dev": true,
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/lightningcss": {
@@ -9854,6 +9979,16 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -9957,6 +10092,37 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/markdown-table": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
@@ -9965,6 +10131,148 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/markdownlint": {
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.38.0.tgz",
+      "integrity": "sha512-xaSxkaU7wY/0852zGApM8LdlIfGCW8ETZ0Rr62IQtAnUMlMuifsg09vWJcNYeL4f0anvr8Vo4ZQar8jGpV0btQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark": "4.0.2",
+        "micromark-core-commonmark": "2.0.3",
+        "micromark-extension-directive": "4.0.0",
+        "micromark-extension-gfm-autolink-literal": "2.1.0",
+        "micromark-extension-gfm-footnote": "2.1.0",
+        "micromark-extension-gfm-table": "2.1.1",
+        "micromark-extension-math": "3.1.0",
+        "micromark-util-types": "2.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/DavidAnson"
+      }
+    },
+    "node_modules/markdownlint-cli": {
+      "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.45.0.tgz",
+      "integrity": "sha512-GiWr7GfJLVfcopL3t3pLumXCYs8sgWppjIA1F/Cc3zIMgD3tmkpyZ1xkm1Tej8mw53B93JsDjgA3KOftuYcfOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "~13.1.0",
+        "glob": "~11.0.2",
+        "ignore": "~7.0.4",
+        "js-yaml": "~4.1.0",
+        "jsonc-parser": "~3.3.1",
+        "jsonpointer": "~5.0.1",
+        "markdown-it": "~14.1.0",
+        "markdownlint": "~0.38.0",
+        "minimatch": "~10.0.1",
+        "run-con": "~1.3.2",
+        "smol-toml": "~1.3.4"
+      },
+      "bin": {
+        "markdownlint": "markdownlint.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/markdownlint-cli/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/markdownlint-cli/node_modules/glob": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
+      "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.0.3",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/markdownlint-cli/node_modules/jackspeak": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/markdownlint-cli/node_modules/lru-cache": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/markdownlint-cli/node_modules/minimatch": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/markdownlint-cli/node_modules/path-scurry": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/math-intrinsics": {
@@ -10253,6 +10561,13 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -10406,6 +10721,26 @@
         "micromark-util-types": "^2.0.0"
       }
     },
+    "node_modules/micromark-extension-directive": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-4.0.0.tgz",
+      "integrity": "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/micromark-extension-gfm": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
@@ -10517,6 +10852,26 @@
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
         "micromark-factory-space": "^2.0.0",
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
@@ -10978,6 +11333,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -11965,6 +12330,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/qs": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
@@ -12531,6 +12906,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/run-con": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/run-con/-/run-con-1.3.2.tgz",
+      "integrity": "sha512-CcfE+mYiTcKEzg0IqS08+efdnH0oJ3zV0wSUFBNrMHMuxCtXvBCLzCJHatwuXDcu/RlhjTziTo/a1ruQik6/Yg==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~4.1.0",
+        "minimist": "^1.2.8",
+        "strip-json-comments": "~3.1.1"
+      },
+      "bin": {
+        "run-con": "cli.js"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -12762,6 +13153,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/smol-toml": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.3.4.tgz",
+      "integrity": "sha512-UOPtVuYkzYGee0Bd2Szz8d2G3RfMfJ2t3qVdZUAozZyAk+a0Sxa+QKix0YCwjL/A1RR0ar44nCxaoN9FxdJGwA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -12979,6 +13383,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strip-literal": {
@@ -13926,6 +14343,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uid-safe": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "test": "vitest run",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "lint:md": "markdownlint README.md \"docs/**/*.md\""
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.894.0",
@@ -113,6 +114,7 @@
     "drizzle-kit": "^0.30.4",
     "esbuild": "^0.25.0",
     "jsdom": "^27.0.0",
+    "markdownlint-cli": "^0.45.0",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.17",
     "tsx": "^4.19.1",

--- a/server/adapters/phonepe-adapter.ts
+++ b/server/adapters/phonepe-adapter.ts
@@ -29,6 +29,7 @@ import type { PaymentProvider, Environment, PhonePeConfig } from "../../shared/p
 import type { ResolvedConfig } from "../services/config-resolver";
 import { PhonePeTokenManager } from "../services/phonepe-token-manager";
 import { PaymentError, RefundError, WebhookError } from "../../shared/payment-types";
+import { resolvePhonePeHost } from "../services/phonepe-host";
 
 /**
  * PhonePe API Response Types
@@ -174,9 +175,7 @@ export class PhonePeAdapter implements PaymentsAdapter {
     this.tokenManager = dependencies.tokenManager;
 
     // Set API base URL based on environment
-    this.baseUrl = this.environment === 'live'
-      ? this.phonepeConfig.hosts.prod
-      : this.phonepeConfig.hosts.uat;
+    this.baseUrl = resolvePhonePeHost(this.phonepeConfig, this.environment);
 
     if (!this.merchantId || !this.salt) {
       throw new PaymentError(

--- a/server/services/__tests__/__fixtures__/phonepe-sandbox/index.ts
+++ b/server/services/__tests__/__fixtures__/phonepe-sandbox/index.ts
@@ -1,0 +1,113 @@
+export interface PhonePeSandboxResponse {
+  success: boolean;
+  code: string;
+  message: string;
+  data: {
+    merchantId: string;
+    merchantTransactionId: string;
+    transactionId: string;
+    amount: number;
+    state: 'PENDING' | 'COMPLETED' | 'FAILED';
+    responseCode: string;
+    paymentInstrument: {
+      type: string;
+      utr?: string;
+      vpa?: string;
+      qrData?: string;
+      qrExpiry?: string;
+    };
+  };
+}
+
+const baseData = {
+  merchantId: 'MID123456789',
+  merchantTransactionId: 'MERCHANT-TXN-001',
+  transactionId: 'PHONEPE-TXN-001',
+  amount: 12345,
+};
+
+export const sandboxUpiSuccess: PhonePeSandboxResponse = {
+  success: true,
+  code: 'PAYMENT_SUCCESS',
+  message: 'Payment completed in sandbox',
+  data: {
+    ...baseData,
+    state: 'COMPLETED',
+    responseCode: 'SUCCESS',
+    paymentInstrument: {
+      type: 'UPI',
+      utr: 'UTR-SANDBOX-0001',
+      vpa: 'success@ybl',
+    },
+  },
+};
+
+export const sandboxUpiFailed: PhonePeSandboxResponse = {
+  success: true,
+  code: 'PAYMENT_DECLINED',
+  message: 'The payer VPA is configured to fail in sandbox',
+  data: {
+    ...baseData,
+    merchantTransactionId: 'MERCHANT-TXN-FAIL',
+    transactionId: 'PHONEPE-TXN-FAIL',
+    state: 'FAILED',
+    responseCode: 'UPI_TXN_FAILED',
+    paymentInstrument: {
+      type: 'UPI',
+      vpa: 'failed@ybl',
+    },
+  },
+};
+
+export const sandboxUpiPending: PhonePeSandboxResponse = {
+  success: true,
+  code: 'PAYMENT_PENDING',
+  message: 'The payer has not yet approved the collect request',
+  data: {
+    ...baseData,
+    merchantTransactionId: 'MERCHANT-TXN-PENDING',
+    transactionId: 'PHONEPE-TXN-PENDING',
+    state: 'PENDING',
+    responseCode: 'PENDING',
+    paymentInstrument: {
+      type: 'UPI',
+      vpa: 'pending@ybl',
+    },
+  },
+};
+
+export const sandboxDynamicQr: PhonePeSandboxResponse = {
+  success: true,
+  code: 'QR_GENERATED',
+  message: 'QR code generated for sandbox checkout',
+  data: {
+    ...baseData,
+    merchantTransactionId: 'MERCHANT-TXN-QR',
+    transactionId: 'PHONEPE-TXN-QR',
+    state: 'PENDING',
+    responseCode: 'PENDING',
+    paymentInstrument: {
+      type: 'QR_CODE',
+      qrData: 'upi://pay?pa=success@ybl&pn=Sandbox%20Merchant&am=123.45&cu=INR',
+      qrExpiry: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+    },
+  },
+};
+
+export const sandboxDynamicQrCompleted: PhonePeSandboxResponse = {
+  success: true,
+  code: 'PAYMENT_SUCCESS',
+  message: 'QR code payment completed',
+  data: {
+    ...baseData,
+    merchantTransactionId: 'MERCHANT-TXN-QR',
+    transactionId: 'PHONEPE-TXN-QR',
+    state: 'COMPLETED',
+    responseCode: 'SUCCESS',
+    paymentInstrument: {
+      type: 'UPI',
+      utr: 'UTR-SANDBOX-QR-0001',
+      vpa: 'success@ybl',
+    },
+  },
+};

--- a/server/services/__tests__/payments-service.test.ts
+++ b/server/services/__tests__/payments-service.test.ts
@@ -250,12 +250,17 @@ describe("PaymentsService.updateStoredPayment lifecycle", () => {
   it("promotes the order only when a verified completed result is processed", async () => {
     const updateSpy = vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn() })) }));
     const eventInsertSpy = vi.fn();
+    let selectCall = 0;
     const selectSpy = vi.fn(() => ({
       from: vi.fn(() => ({
         where: vi.fn(() => ({
-          limit: vi.fn(async () => [
-            { orderId: "ord_1", currentStatus: "processing" },
-          ]),
+          limit: vi.fn(async () => {
+            selectCall += 1;
+            if (selectCall === 1) {
+              return [{ orderId: "ord_1", currentStatus: "processing" }];
+            }
+            return [{ paymentStatus: "pending" }];
+          }),
         })),
       })),
     }));
@@ -283,12 +288,17 @@ describe("PaymentsService.updateStoredPayment lifecycle", () => {
   it("allows verified completion replays to promote the order", async () => {
     const updateSpy = vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn() })) }));
     const eventInsertSpy = vi.fn();
+    let selectCall = 0;
     const selectSpy = vi.fn(() => ({
       from: vi.fn(() => ({
         where: vi.fn(() => ({
-          limit: vi.fn(async () => [
-            { orderId: "ord_1", currentStatus: "captured" },
-          ]),
+          limit: vi.fn(async () => {
+            selectCall += 1;
+            if (selectCall === 1) {
+              return [{ orderId: "ord_1", currentStatus: "captured" }];
+            }
+            return [{ paymentStatus: "pending" }];
+          }),
         })),
       })),
     }));

--- a/server/services/__tests__/phonepe-flows.test.ts
+++ b/server/services/__tests__/phonepe-flows.test.ts
@@ -252,6 +252,9 @@ describe("PhonePe UPI happy path", () => {
           amountCapturedMinor: 0,
         },
       ],
+      [
+        { paymentStatus: "pending" },
+      ],
     ]);
 
     const res = createMockResponse();
@@ -314,6 +317,9 @@ describe("PhonePe callback/webhook ordering", () => {
           provider: "phonepe",
         },
       ],
+      [
+        { paymentStatus: "pending" },
+      ],
     ]);
     updateRowCounts.push(1, 1, 1, 0, 1);
     adapter.verifyPayment.mockResolvedValue(phonePeImmediateCapture);
@@ -337,6 +343,9 @@ describe("PhonePe callback/webhook ordering", () => {
           amountAuthorizedMinor: phonePeCreatePayment.amount,
           amountCapturedMinor: phonePeCreatePayment.amount,
         },
+      ],
+      [
+        { paymentStatus: "paid" },
       ],
     ]);
 
@@ -382,6 +391,9 @@ describe("PhonePe callback/webhook ordering", () => {
           amountCapturedMinor: 0,
         },
       ],
+      [
+        { paymentStatus: "pending" },
+      ],
     ]);
     await router.processWebhook(
       "phonepe",
@@ -406,6 +418,9 @@ describe("PhonePe callback/webhook ordering", () => {
           amountAuthorizedMinor: phonePeCreatePayment.amount,
           provider: "phonepe",
         },
+      ],
+      [
+        { paymentStatus: "paid" },
       ],
     ]);
     updateRowCounts.push(1, 0);

--- a/server/services/config-resolver.ts
+++ b/server/services/config-resolver.ts
@@ -271,6 +271,12 @@ export class ConfigResolver {
       ]
     );
 
+    const hosts = phonepeSecrets.hosts;
+    const secretActiveHost = typeof phonepeSecrets.activeHost === 'string'
+      ? phonepeSecrets.activeHost.trim()
+      : undefined;
+    const metadataActiveHost = this.pickPhonePeHostSelection(dbConfig?.metadata ?? null);
+
     return {
       client_id: phonepeSecrets.client_id,
       client_secret: phonepeSecrets.client_secret,
@@ -278,7 +284,8 @@ export class ConfigResolver {
       merchantId,
       webhookAuth: phonepeSecrets.webhookAuth,
       redirectUrl,
-      hosts: phonepeSecrets.hosts,
+      hosts,
+      activeHost: metadataActiveHost ?? secretActiveHost,
     };
   }
 
@@ -310,6 +317,23 @@ export class ConfigResolver {
     }
 
     return available[0].value;
+  }
+
+  private pickPhonePeHostSelection(metadata: Record<string, any> | null): string | undefined {
+    if (!metadata) {
+      return undefined;
+    }
+
+    const fromFlat = typeof metadata.phonepeHost === 'string' ? metadata.phonepeHost : undefined;
+    const fromNested = typeof metadata.phonepe?.host === 'string' ? metadata.phonepe.host : undefined;
+    const raw = fromFlat ?? fromNested;
+
+    if (typeof raw !== 'string') {
+      return undefined;
+    }
+
+    const trimmed = raw.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
   }
   
   /**

--- a/server/services/phonepe-host.ts
+++ b/server/services/phonepe-host.ts
@@ -1,0 +1,17 @@
+import type { Environment, PhonePeConfig } from "../../shared/payment-providers";
+
+export function resolvePhonePeHost(config: PhonePeConfig, environment: Environment): string {
+  const selection = typeof config.activeHost === 'string' ? config.activeHost.trim() : '';
+
+  if (selection) {
+    if (selection === 'uat' || selection === 'prod') {
+      return config.hosts[selection];
+    }
+
+    return selection;
+  }
+
+  return environment === 'live'
+    ? config.hosts.prod
+    : config.hosts.uat;
+}

--- a/server/services/phonepe-service.ts
+++ b/server/services/phonepe-service.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import type { Environment, PhonePeConfig } from '../../shared/payment-providers';
 import { PhonePeTokenManager } from './phonepe-token-manager';
+import { resolvePhonePeHost } from './phonepe-host';
 
 export interface PhonePeCredentials {
   saltKey: string;
@@ -75,9 +76,7 @@ export class PhonePeService {
     this.credentials = options.credentials;
     this.environment = options.environment;
     this.tokenManager = options.tokenManager;
-    this.apiHost = this.environment === 'live'
-      ? this.config.hosts.prod
-      : this.config.hosts.uat;
+    this.apiHost = resolvePhonePeHost(this.config, this.environment);
   }
 
   /**

--- a/server/services/phonepe-token-manager.ts
+++ b/server/services/phonepe-token-manager.ts
@@ -1,4 +1,5 @@
 import type { Environment, PhonePeConfig } from '../../shared/payment-providers';
+import { resolvePhonePeHost } from './phonepe-host';
 
 interface PhonePeAuthorizationResponse {
   accessToken: string;
@@ -146,9 +147,7 @@ export class PhonePeTokenManager {
   }
 
   private buildAuthorizationUrl(): string {
-    const baseUrl = this.environment === 'live'
-      ? this.config.hosts.prod
-      : this.config.hosts.uat;
+    const baseUrl = resolvePhonePeHost(this.config, this.environment);
 
     return `${baseUrl.replace(/\/$/, '')}/v3/authorization/oauth/token`;
   }

--- a/server/utils/secrets-resolver.ts
+++ b/server/utils/secrets-resolver.ts
@@ -12,7 +12,10 @@ import type {
   PaymentProvider,
   Environment,
   PhonePeConfig,
+  PhonePeHosts,
+  PhonePeHostSelection,
 } from "../../shared/payment-providers";
+import { PHONEPE_DEFAULT_HOSTS } from "../../shared/payment-providers";
 import { ConfigurationError } from "../../shared/payment-types";
 
 interface PhonePeSecretConfig {
@@ -20,7 +23,8 @@ interface PhonePeSecretConfig {
   client_secret: PhonePeConfig["client_secret"];
   client_version: PhonePeConfig["client_version"];
   webhookAuth: PhonePeConfig["webhookAuth"];
-  hosts: PhonePeConfig["hosts"];
+  hosts: PhonePeHosts;
+  activeHost?: PhonePeHostSelection;
   redirectUrl?: PhonePeConfig["redirectUrl"];
   merchantId?: PhonePeConfig["merchantId"];
 }
@@ -165,6 +169,10 @@ export class SecretsResolver {
           }
         }
 
+        const hostUat = getOptionalEnvValue(`${environmentPrefix}HOST_UAT`) ?? PHONEPE_DEFAULT_HOSTS.uat;
+        const hostProd = getOptionalEnvValue(`${environmentPrefix}HOST_PROD`) ?? PHONEPE_DEFAULT_HOSTS.prod;
+        const activeHost = getOptionalEnvValue(`${environmentPrefix}HOST_ACTIVE`);
+
         secrets.phonepe = {
           client_id: resolvedEnvValues[`${environmentPrefix}CLIENT_ID`],
           client_secret: resolvedEnvValues[`${environmentPrefix}CLIENT_SECRET`],
@@ -174,9 +182,10 @@ export class SecretsResolver {
             password: resolvedEnvValues[`${environmentPrefix}WEBHOOK_PASSWORD`],
           },
           hosts: {
-            uat: resolvedEnvValues[`${environmentPrefix}HOST_UAT`],
-            prod: resolvedEnvValues[`${environmentPrefix}HOST_PROD`],
+            uat: hostUat,
+            prod: hostProd,
           },
+          activeHost: activeHost,
         };
 
         {

--- a/shared/payment-providers.ts
+++ b/shared/payment-providers.ts
@@ -1,5 +1,17 @@
 import { z } from "zod";
 
+export interface PhonePeHosts {
+  uat: string;
+  prod: string;
+}
+
+export type PhonePeHostSelection = keyof PhonePeHosts | string;
+
+export const PHONEPE_DEFAULT_HOSTS: PhonePeHosts = {
+  uat: 'https://api-preprod.phonepe.com/apis/pgsandbox',
+  prod: 'https://api.phonepe.com/apis/hermes',
+};
+
 // Payment provider enum - exactly 8 providers as specified
 export const PaymentProviderEnum = z.enum([
   'razorpay',
@@ -28,10 +40,8 @@ export interface PhonePeConfig {
     password: string;
   };
   redirectUrl: string;
-  hosts: {
-    uat: string;
-    prod: string;
-  };
+  hosts: PhonePeHosts;
+  activeHost?: PhonePeHostSelection;
 }
 
 // Capability matrix interface
@@ -189,8 +199,6 @@ export const providerSecretKeys: Record<PaymentProvider, {
       'PAYAPP_TEST_PHONEPE_CLIENT_VERSION',
       'PAYAPP_TEST_PHONEPE_WEBHOOK_USERNAME',
       'PAYAPP_TEST_PHONEPE_WEBHOOK_PASSWORD',
-      'PAYAPP_TEST_PHONEPE_HOST_UAT',
-      'PAYAPP_TEST_PHONEPE_HOST_PROD',
       'PAYAPP_TEST_PHONEPE_REDIRECT_URL',
     ],
     live: [
@@ -201,8 +209,6 @@ export const providerSecretKeys: Record<PaymentProvider, {
       'PAYAPP_LIVE_PHONEPE_CLIENT_VERSION',
       'PAYAPP_LIVE_PHONEPE_WEBHOOK_USERNAME',
       'PAYAPP_LIVE_PHONEPE_WEBHOOK_PASSWORD',
-      'PAYAPP_LIVE_PHONEPE_HOST_UAT',
-      'PAYAPP_LIVE_PHONEPE_HOST_PROD',
       'PAYAPP_LIVE_PHONEPE_REDIRECT_URL',
     ],
   },


### PR DESCRIPTION
## Summary
- add default PhonePe hosts, activeHost selection, and helpers to resolve the runtime base URL
- extend tests, services, and new fixtures for sandbox VPAs and QR flows while documenting setup in README/user journeys
- introduce markdown lint configuration and npm script for documentation checks

## Testing
- npm run lint:md
- npm run check
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dbe92c0b34832a8f67de74cbe6ef7d