### PR TITLE
Normalize PhonePe lifecycle status handling

### DIFF
--- a/client/src/pages/__tests__/thank-you.test.tsx
+++ b/client/src/pages/__tests__/thank-you.test.tsx
@@ -64,7 +64,7 @@ describe("Thank-you page", () => {
       },
       latestTransaction: {
         id: "txn-captured",
-        status: "captured",
+        status: "COMPLETED",
         merchantTransactionId: "MERCHANT_TXN_123",
         providerTransactionId: "PG_TXN_123",
         upiUtr: "UTR1234567",

--- a/client/src/pages/thank-you.tsx
+++ b/client/src/pages/thank-you.tsx
@@ -241,9 +241,9 @@ export default function ThankYou() {
     refetchInterval: (queryData) => {
       // Stop polling on terminal states
       const data = queryData?.state?.data as PaymentStatusInfo | undefined;
-      if (data?.latestTransaction?.status === 'completed' ||
-          data?.latestTransaction?.status === 'failed' ||
-          data?.order?.paymentStatus === 'paid') {
+      const latestStatus = normalizeStatus(data?.latestTransaction?.status);
+      const orderPaymentStatus = normalizeStatus(data?.order?.paymentStatus);
+      if (['completed', 'failed'].includes(latestStatus) || orderPaymentStatus === 'paid') {
         return false;
       }
 

--- a/migrations/0004_payments_upi_capture_guard.sql
+++ b/migrations/0004_payments_upi_capture_guard.sql
@@ -2,4 +2,4 @@
 CREATE UNIQUE INDEX IF NOT EXISTS payments_upi_captured_order_unique
   ON payments (order_id)
   WHERE method_kind = 'upi'
-    AND status IN ('captured','completed','succeeded','success','paid');
+    AND status IN ('captured','completed','COMPLETED','succeeded','success','paid');

--- a/server/adapters/__tests__/phonepe-adapter.test.ts
+++ b/server/adapters/__tests__/phonepe-adapter.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ResolvedConfig } from '../../services/config-resolver';
 import { PhonePeAdapter } from '../phonepe-adapter';
+import { normalizePaymentLifecycleStatus } from '../../../shared/payment-types';
 
 const baseConfig: ResolvedConfig = {
   provider: 'phonepe',
@@ -193,7 +194,9 @@ describe('PhonePeAdapter status normalization', () => {
   it('maps success and failure states without mislabeling cancellations', () => {
     const adapter = buildAdapter();
 
-    expect((adapter as any).mapPaymentStatus('completed')).toBe('captured');
+    expect(
+      normalizePaymentLifecycleStatus((adapter as any).mapPaymentStatus('completed'))
+    ).toBe('COMPLETED');
     expect((adapter as any).mapPaymentStatus('pending')).toBe('processing');
     expect((adapter as any).mapPaymentStatus('failed')).toBe('failed');
     expect((adapter as any).mapPaymentStatus('  unknown_state  ')).toBe('processing');

--- a/server/routes/__tests__/payments-router.test.ts
+++ b/server/routes/__tests__/payments-router.test.ts
@@ -273,10 +273,10 @@ describe("payments router", () => {
       expect(res.jsonPayload.payment.providerTransactionId).toBe("txn");
     });
 
-    it("prioritizes captured UPI payment details", async () => {
+    it("prioritizes completed UPI payment details", async () => {
       const captured = {
         id: "pay_captured",
-        status: "captured",
+        status: "COMPLETED",
         provider: "phonepe",
         methodKind: "upi",
         amountAuthorizedMinor: 1000,
@@ -298,6 +298,7 @@ describe("payments router", () => {
       });
 
       expect(res.jsonPayload.order.paymentStatus).toBe("paid");
+      expect(res.jsonPayload.payment.status).toBe("COMPLETED");
       expect(res.jsonPayload.payment.upiUtr).toBe("123456");
       expect(res.jsonPayload.payment.receiptUrl).toBe("https://receipt");
       expect(res.jsonPayload.totals.paidMinor).toBe(1000);
@@ -334,7 +335,7 @@ describe("payments router", () => {
     it("handles webhook-first captures before order promotion", async () => {
       const captured = {
         id: "pay_captured",
-        status: "captured",
+        status: "COMPLETED",
         provider: "phonepe",
         methodKind: "upi",
         amountAuthorizedMinor: 1000,
@@ -355,7 +356,7 @@ describe("payments router", () => {
       });
 
       expect(res.jsonPayload.order.paymentStatus).toBe("pending");
-      expect(res.jsonPayload.payment.status).toBe("captured");
+      expect(res.jsonPayload.payment.status).toBe("COMPLETED");
       expect(res.jsonPayload.totals.paidMinor).toBe(1000);
     });
   });

--- a/server/services/__tests__/phonepe-flows.test.ts
+++ b/server/services/__tests__/phonepe-flows.test.ts
@@ -267,7 +267,7 @@ describe("PhonePe UPI happy path", () => {
     expect(res.statusCode).toBe(200);
     expect(res.jsonPayload).toMatchObject({ status: "processed" });
 
-    const paymentUpdate = updateCalls.find((call) => call.table === payments && call.data.status === "captured");
+    const paymentUpdate = updateCalls.find((call) => call.table === payments && call.data.status === "COMPLETED");
     expect(paymentUpdate?.data).toMatchObject({
       amountCapturedMinor: phonePeCreatePayment.amount,
       upiPayerHandle: "buyer@upi",
@@ -303,7 +303,7 @@ describe("PhonePe callback/webhook ordering", () => {
       {
         id: "pay_test_123",
         provider: "phonepe",
-        status: "processing",
+        status: "PENDING",
         tenantId: "default",
         providerPaymentId: "pg_payment_123",
       },
@@ -312,7 +312,7 @@ describe("PhonePe callback/webhook ordering", () => {
       [
         {
           orderId: "order-1",
-          currentStatus: "processing",
+          currentStatus: "PENDING",
           amountAuthorizedMinor: phonePeCreatePayment.amount,
           provider: "phonepe",
         },
@@ -405,7 +405,7 @@ describe("PhonePe callback/webhook ordering", () => {
       {
         id: "pay_test_123",
         provider: "phonepe",
-        status: "captured",
+        status: "COMPLETED",
         tenantId: "default",
         providerPaymentId: "pg_payment_123",
       },
@@ -414,7 +414,7 @@ describe("PhonePe callback/webhook ordering", () => {
       [
         {
           orderId: "order-1",
-          currentStatus: "captured",
+          currentStatus: "COMPLETED",
           amountAuthorizedMinor: phonePeCreatePayment.amount,
           provider: "phonepe",
         },
@@ -474,7 +474,7 @@ describe("PhonePe exceptional flows", () => {
     );
 
     expect(res.jsonPayload).toMatchObject({ status: "processed" });
-    const paymentUpdate = updateCalls.find((call) => call.table === payments && call.data.status === "cancelled");
+    const paymentUpdate = updateCalls.find((call) => call.table === payments && call.data.status === "CANCELLED");
     expect(paymentUpdate).toBeTruthy();
     const orderUpdate = updateCalls.find((call) => call.table === orders && call.data.paymentStatus === "paid");
     expect(orderUpdate).toBeUndefined();
@@ -518,7 +518,7 @@ describe("PhonePe exceptional flows", () => {
       res
     );
 
-    const paymentUpdate = updateCalls.find((call) => call.table === payments && call.data.status === "cancelled");
+    const paymentUpdate = updateCalls.find((call) => call.table === payments && call.data.status === "CANCELLED");
     expect(paymentUpdate).toBeTruthy();
   });
 

--- a/server/services/phonepe-polling-worker.ts
+++ b/server/services/phonepe-polling-worker.ts
@@ -96,6 +96,7 @@ export const PHONEPE_POLL_INTERVALS_SECONDS = Object.freeze([15, 30, 60, 120, 24
 const TERMINAL_SUCCESS_STATUSES = new Set([
   "captured",
   "completed",
+  "COMPLETED",
   "paid",
   "succeeded",
   "success",
@@ -103,6 +104,7 @@ const TERMINAL_SUCCESS_STATUSES = new Set([
 
 const TERMINAL_FAILURE_STATUSES = new Set([
   "failed",
+  "FAILED",
   "cancelled",
   "canceled",
   "timedout",

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -221,7 +221,7 @@ export const payments = pgTable("payments", {
   uniqueUpiCapturePerOrder: uniqueIndex("payments_upi_captured_order_unique")
     .on(table.orderId)
     .where(
-      sql`${table.methodKind} = 'upi' AND ${table.status} IN ('captured','completed','succeeded','success','paid')`
+      sql`${table.methodKind} = 'upi' AND ${table.status} IN ('captured','completed','COMPLETED','succeeded','success','paid')`
     ),
 }));
 


### PR DESCRIPTION
## Summary
- add shared lifecycle normalization helpers and apply them to PaymentsService and the webhook router so PhonePe captures persist as `COMPLETED`
- tighten transition logic to block non-forward updates and only promote orders on first `COMPLETED` verification
- update PhonePe flows, router, and UI expectations plus tests to assert normalized storage and idempotent handling of terminal webhooks

## Testing
- npm run check
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68dbfa857a78832a8bd2b491078eb0a1