### PR TITLE
Add PhonePe admin reconciliation console and tests

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,6 +11,7 @@ import Cart from "@/pages/cart";
 import Checkout from "@/pages/checkout";
 import Payment from "@/pages/payment";
 import Admin from "@/pages/admin";
+import PhonePeReconciliationAdminPage from "@/pages/admin/phonepe-reconciliation";
 import Influencer from "@/pages/influencer";
 import ThankYou from "@/pages/thank-you";
 import UserOrders from "@/pages/user-orders";
@@ -24,6 +25,7 @@ function Router() {
     <ErrorBoundary>
       <Switch>
         {/* Full-screen admin and influencer pages */}
+        <Route path="/admin/phonepe-reconciliation" component={PhonePeReconciliationAdminPage} />
         <Route path="/admin" component={Admin} />
         <Route path="/influencer" component={Influencer} />
         

--- a/client/src/pages/__tests__/admin-phonepe-reconciliation.test.tsx
+++ b/client/src/pages/__tests__/admin-phonepe-reconciliation.test.tsx
@@ -1,0 +1,226 @@
+import React from "react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Request, Response as ExpressResponse } from "express";
+import type { Router } from "express";
+import PhonePeReconciliationAdminPage from "../admin/phonepe-reconciliation";
+
+const setLocationMock = vi.fn();
+
+vi.mock("wouter", async () => {
+  const actual = await vi.importActual<typeof import("wouter")>("wouter");
+  return {
+    ...actual,
+    useLocation: () => ["/admin/phonepe-reconciliation?orderId=order-123", setLocationMock] as const,
+  };
+});
+
+const mockPaymentsService = {
+  verifyPayment: vi.fn(),
+  performHealthCheck: vi.fn(),
+  createPayment: vi.fn(),
+  createRefund: vi.fn(),
+  getRefundStatus: vi.fn(),
+};
+
+vi.mock("../../../../server/services/payments-service", () => ({
+  createPaymentsService: () => mockPaymentsService,
+}));
+
+const mockOrdersRepository = {
+  getOrderWithPayments: vi.fn(),
+};
+
+const mockPhonePePollingStore = {
+  getLatestJobForOrder: vi.fn(),
+};
+
+vi.mock("../../../../server/storage", () => ({
+  ordersRepository: mockOrdersRepository,
+  phonePePollingStore: mockPhonePePollingStore,
+}));
+
+vi.mock("../../../../server/services/phonepe-polling-registry", () => ({
+  phonePePollingWorker: { registerJob: vi.fn() },
+}));
+
+process.env.DATABASE_URL ??= "postgres://user:pass@localhost:5432/test";
+
+const buildResponse = () => {
+  const res: Partial<ExpressResponse> & { statusCode?: number; jsonPayload?: any } = {};
+  res.status = vi.fn((code: number) => {
+    res.statusCode = code;
+    return res as ExpressResponse;
+  }) as any;
+  res.json = vi.fn((payload: any) => {
+    res.jsonPayload = payload;
+    return res as ExpressResponse;
+  }) as any;
+  return res as ExpressResponse & { statusCode?: number; jsonPayload?: any };
+};
+
+const buildRouter = async () => {
+  const module = await import("../../../../server/routes/payments");
+  return module.createPaymentsRouter((_req, _res, next) => next());
+};
+
+const getRouteHandler = (router: Router, method: "get", path: string) => {
+  const layer = router.stack.find(
+    (entry: any) => entry.route?.path === path && entry.route?.methods?.[method]
+  );
+  if (!layer) {
+    throw new Error(`Route ${method.toUpperCase()} ${path} not found`);
+  }
+  const stack = layer.route.stack;
+  const routeLayer = stack[stack.length - 1];
+  return routeLayer.handle as (req: Request, res: ExpressResponse, next: () => void) => Promise<void> | void;
+};
+
+describe("Admin PhonePe reconciliation page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders gateway status and UPI references from the admin endpoint", async () => {
+    const order = {
+      id: "order-123",
+      tenantId: "tenant-a",
+      payments: [
+        {
+          id: "pay_1",
+          provider: "phonepe",
+          status: "processing",
+          providerPaymentId: "merchant-1",
+          providerReferenceId: "merchant-1",
+          providerTransactionId: "pg-1",
+          upiPayerHandle: "payer@upi",
+          upiUtr: "UTR-MASKED",
+          amountAuthorizedMinor: 1000,
+          amountCapturedMinor: 0,
+          createdAt: new Date("2024-01-01T00:00:00Z"),
+          updatedAt: new Date("2024-01-01T00:01:00Z"),
+        },
+      ],
+      user: {},
+      deliveryAddress: {},
+    };
+
+    mockOrdersRepository.getOrderWithPayments.mockResolvedValue(order);
+    mockPaymentsService.verifyPayment.mockResolvedValue({
+      paymentId: "pay_1",
+      providerPaymentId: "merchant-1",
+      providerOrderId: "pg-1",
+      status: "completed",
+      amount: 1000,
+      currency: "INR",
+      provider: "phonepe",
+      environment: "test",
+      providerData: {
+        state: "COMPLETED",
+        responseCode: "SUCCESS",
+        utr: "UTR123456",
+        upiPayerHandle: "payer@upi",
+        paymentInstrument: {
+          type: "UPI_COLLECT",
+          utr: "UTR123456",
+          payerVpa: "payer@upi",
+          payerAddress: "payer@upi",
+        },
+      },
+      createdAt: new Date("2024-01-01T00:02:00Z"),
+      updatedAt: new Date("2024-01-01T00:02:30Z"),
+    });
+
+    mockPhonePePollingStore.getLatestJobForOrder.mockResolvedValue({
+      status: "pending",
+      attempt: 2,
+      nextPollAt: new Date("2024-01-01T00:05:00Z"),
+      expireAt: new Date("2024-01-01T00:10:00Z"),
+      lastStatus: "PENDING",
+      lastResponseCode: "PAYMENT_PENDING",
+      lastError: null,
+      completedAt: null,
+      lastPolledAt: new Date("2024-01-01T00:04:00Z"),
+    });
+
+    window.history.replaceState({}, "", "/admin/phonepe-reconciliation?orderId=order-123");
+
+    const router = await buildRouter();
+    const handler = getRouteHandler(router, "get", "/admin/phonepe/orders/:orderId");
+
+    const debugReq = {
+      params: { orderId: "order-123" },
+      headers: {},
+      session: { adminId: "admin-1", userRole: "admin" },
+    } as unknown as Request;
+    const debugRes = buildResponse();
+    try {
+      await handler(debugReq, debugRes, () => {});
+    } catch (error) {
+      throw new Error(`handler error: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    expect(mockOrdersRepository.getOrderWithPayments).toHaveBeenCalledWith("order-123");
+    expect(mockPaymentsService.verifyPayment).toHaveBeenCalled();
+    expect(debugRes.jsonPayload?.success).toBe(true);
+    mockOrdersRepository.getOrderWithPayments.mockClear();
+    mockPaymentsService.verifyPayment.mockClear();
+    mockPhonePePollingStore.getLatestJobForOrder.mockClear();
+
+    global.fetch = vi.fn(async (input: RequestInfo) => {
+      const url = typeof input === "string" ? input : input.url;
+      if (url === "/api/admin/me") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ authenticated: true, role: "admin", id: "admin-1" }),
+        } as any;
+      }
+      if (url.startsWith("/api/payments/admin/phonepe/orders/")) {
+        const orderId = decodeURIComponent(url.split("/" ).pop() ?? "");
+        const req = {
+          params: { orderId },
+          headers: {},
+          session: { adminId: "admin-1", userRole: "admin" },
+        } as unknown as Request;
+        const res = buildResponse();
+        await handler(req, res, () => {});
+        if (!res.jsonPayload) {
+          throw new Error("handler returned no payload");
+        }
+        return {
+          ok: !res.statusCode || res.statusCode < 400,
+          status: res.statusCode ?? 200,
+          json: async () => res.jsonPayload,
+        } as any;
+      }
+      throw new Error(`Unhandled fetch ${url}`);
+    }) as any;
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    queryClient.setQueryData(["/api/admin/me"], { authenticated: true, role: "admin", id: "admin-1" });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <PhonePeReconciliationAdminPage />
+      </QueryClientProvider>
+    );
+
+    const orderInput = await screen.findByTestId("input-order-id");
+    fireEvent.change(orderInput, { target: { value: "order-123" } });
+    const form = orderInput.closest("form");
+    if (!form) {
+      throw new Error("Form not found for order lookup");
+    }
+    fireEvent.submit(form);
+
+    await waitFor(() => expect(mockPaymentsService.verifyPayment).toHaveBeenCalled());
+
+    expect(await screen.findByTestId("badge-provider-status")).toHaveTextContent("COMPLETED");
+    expect(screen.getByTestId("text-upi-utr")).toHaveTextContent("UTR123456");
+    expect(screen.getByTestId("text-upi-handle")).toHaveTextContent("payer@upi");
+    expect(screen.getByTestId("badge-reconciliation-status")).toHaveTextContent("PENDING");
+  });
+});

--- a/client/src/pages/admin/phonepe-reconciliation.tsx
+++ b/client/src/pages/admin/phonepe-reconciliation.tsx
@@ -1,0 +1,385 @@
+import { useMemo, useState } from "react";
+import { useLocation } from "wouter";
+import { useQuery } from "@tanstack/react-query";
+import { useAdminAuth } from "@/hooks/use-auth";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { LoadingSpinner } from "@/components/ui/loading-spinner";
+
+interface PhonePeInstrumentDetails {
+  type: string | null;
+  utr: string | null;
+  utrMasked: string | null;
+  payerHandle: string | null;
+  payerHandleMasked: string | null;
+  payerVpa: string | null;
+  payerAddress: string | null;
+  variant: string | null;
+  variantLabel: string | null;
+}
+
+interface PhonePeReconciliationMarker {
+  status: string;
+  attempt: number;
+  nextPollAt?: string;
+  expiresAt?: string;
+  lastStatus?: string | null;
+  lastResponseCode?: string | null;
+  lastError?: string | null;
+  completedAt?: string | null;
+  lastPolledAt?: string | null;
+}
+
+interface PhonePeRecordedPayment {
+  status: string;
+  providerPaymentId?: string;
+  providerReferenceId?: string;
+  upiPayerHandle?: string;
+  upiUtr?: string;
+  updatedAt?: string | null;
+}
+
+interface PhonePeAdminOrderData {
+  orderId: string;
+  tenantId: string;
+  paymentId: string;
+  merchantTransactionId: string;
+  providerStatus: string;
+  phonePeState: string | null;
+  responseCode: string | null;
+  amountMinor: number;
+  amount: number;
+  currency: string;
+  verifiedAt?: string;
+  instrument: PhonePeInstrumentDetails;
+  rawInstrument: Record<string, unknown> | null;
+  recordedPayment: PhonePeRecordedPayment;
+  reconciliation: PhonePeReconciliationMarker | null;
+}
+
+interface PhonePeAdminResponse {
+  success: boolean;
+  data: PhonePeAdminOrderData;
+}
+
+function formatDate(value?: string | null) {
+  if (!value) return "–";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "–";
+  }
+  return new Intl.DateTimeFormat("en-IN", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
+function resolveOrderIdFromSearch(search: string): string {
+  if (!search) {
+    return "";
+  }
+  const query = new URLSearchParams(search);
+  return query.get("orderId") ?? "";
+}
+
+export default function PhonePeReconciliationAdminPage() {
+  const { isAuthenticated, isLoading } = useAdminAuth();
+  const [location, setLocation] = useLocation();
+
+  const initialOrderId = useMemo(() => {
+    if (typeof window === "undefined") {
+      return "";
+    }
+    return resolveOrderIdFromSearch(window.location.search);
+  }, []);
+
+  const [inputOrderId, setInputOrderId] = useState(initialOrderId);
+  const [orderId, setOrderId] = useState(initialOrderId);
+
+  const {
+    data,
+    isFetching,
+    error,
+    refetch,
+  } = useQuery<PhonePeAdminResponse, Error, PhonePeAdminOrderData>({
+    queryKey: ["/api/payments/admin/phonepe/orders", orderId],
+    enabled: isAuthenticated && orderId.trim().length > 0,
+    staleTime: 0,
+    queryFn: async () => {
+      const response = await fetch(`/api/payments/admin/phonepe/orders/${encodeURIComponent(orderId)}`);
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        const message = (body as { error?: string; message?: string }).error
+          || (body as { error?: string; message?: string }).message
+          || "Failed to fetch PhonePe order status";
+        throw new Error(message);
+      }
+      const payload = (await response.json()) as PhonePeAdminResponse;
+      if (!payload.success) {
+        throw new Error("PhonePe order status lookup failed");
+      }
+      return payload;
+    },
+    select: (result) => result.data,
+  });
+
+  const handleLookup = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = inputOrderId.trim();
+    setOrderId(trimmed);
+    if (typeof window !== "undefined") {
+      const query = new URLSearchParams(window.location.search);
+      if (trimmed) {
+        query.set("orderId", trimmed);
+      } else {
+        query.delete("orderId");
+      }
+      const next = `${window.location.pathname}${query.toString() ? `?${query.toString()}` : ""}`;
+      if (next !== location) {
+        setLocation(next, { replace: true });
+      }
+    }
+    if (trimmed) {
+      void refetch();
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="py-20">
+        <LoadingSpinner text="Checking admin session…" />
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <div className="max-w-2xl mx-auto py-20 text-center space-y-4">
+        <Card>
+          <CardHeader>
+            <CardTitle>Admin access required</CardTitle>
+            <CardDescription>
+              Sign in to the admin console to review PhonePe reconciliation status.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto py-10 space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>PhonePe reconciliation lookup</CardTitle>
+          <CardDescription>
+            Inspect the live order status returned by PhonePe and compare it with the stored payment snapshot.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form className="flex flex-col sm:flex-row gap-3" onSubmit={handleLookup}>
+            <Input
+              value={inputOrderId}
+              onChange={(event) => setInputOrderId(event.target.value)}
+              placeholder="Enter order ID"
+              data-testid="input-order-id"
+            />
+            <Button type="submit" disabled={inputOrderId.trim().length === 0}>
+              Lookup order
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                if (orderId.trim().length === 0) return;
+                void refetch();
+              }}
+              disabled={orderId.trim().length === 0 || isFetching}
+            >
+              Refresh status
+            </Button>
+          </form>
+          {orderId.trim().length === 0 && (
+            <p className="text-sm text-muted-foreground mt-4">
+              Provide an order ID to retrieve reconciliation signals from PhonePe.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      {isFetching && (
+        <Card>
+          <CardContent className="py-10">
+            <LoadingSpinner text="Fetching latest PhonePe status…" />
+          </CardContent>
+        </Card>
+      )}
+
+      {error && !isFetching && (
+        <Card className="border-red-300 bg-red-50">
+          <CardHeader>
+            <CardTitle className="text-red-700">Lookup failed</CardTitle>
+            <CardDescription className="text-red-600">{error.message}</CardDescription>
+          </CardHeader>
+        </Card>
+      )}
+
+      {data && !isFetching && (
+        <>
+          <Card>
+            <CardHeader>
+              <CardTitle>Gateway status</CardTitle>
+              <CardDescription>
+                PhonePe reports the following state for merchant transaction <strong>{data.merchantTransactionId}</strong>.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex flex-wrap gap-3 items-center">
+                <Badge variant="outline" data-testid="badge-provider-status">
+                  {data.providerStatus.toUpperCase()}
+                </Badge>
+                {data.phonePeState && (
+                  <Badge data-testid="text-phonepe-state">State: {data.phonePeState}</Badge>
+                )}
+                {data.responseCode && (
+                  <Badge variant="secondary" data-testid="text-response-code">
+                    Code: {data.responseCode}
+                  </Badge>
+                )}
+              </div>
+              <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
+                <div>
+                  <dt className="text-muted-foreground">Amount</dt>
+                  <dd className="font-medium">
+                    {new Intl.NumberFormat("en-IN", { style: "currency", currency: data.currency }).format(
+                      data.amount,
+                    )}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-muted-foreground">Last verified</dt>
+                  <dd className="font-medium">{formatDate(data.verifiedAt)}</dd>
+                </div>
+                <div>
+                  <dt className="text-muted-foreground">Payment ID</dt>
+                  <dd className="font-mono break-all">{data.paymentId}</dd>
+                </div>
+                <div>
+                  <dt className="text-muted-foreground">Stored payment status</dt>
+                  <dd className="font-medium">{data.recordedPayment.status}</dd>
+                </div>
+              </dl>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>UPI instrument details</CardTitle>
+              <CardDescription>
+                Review the UPI metadata returned by PhonePe alongside the masked identifiers stored in the order record.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Field</TableHead>
+                    <TableHead>Value</TableHead>
+                    <TableHead>Masked / stored</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  <TableRow>
+                    <TableCell>Variant</TableCell>
+                    <TableCell>{data.instrument.variantLabel ?? data.instrument.variant ?? "–"}</TableCell>
+                    <TableCell>—</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell>UTR</TableCell>
+                    <TableCell data-testid="text-upi-utr">{data.instrument.utr ?? "–"}</TableCell>
+                    <TableCell>{data.instrument.utrMasked ?? data.recordedPayment.upiUtr ?? "–"}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell>Payer handle</TableCell>
+                    <TableCell data-testid="text-upi-handle">{data.instrument.payerHandle ?? "–"}</TableCell>
+                    <TableCell>{data.instrument.payerHandleMasked ?? data.recordedPayment.upiPayerHandle ?? "–"}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell>Payer VPA</TableCell>
+                    <TableCell>{data.instrument.payerVpa ?? "–"}</TableCell>
+                    <TableCell>{data.recordedPayment.upiPayerHandle ?? "–"}</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell>Payer address</TableCell>
+                    <TableCell>{data.instrument.payerAddress ?? "–"}</TableCell>
+                    <TableCell>—</TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Reconciliation markers</CardTitle>
+              <CardDescription>
+                Status from the PhonePe polling registry used to drive automated follow-ups.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {data.reconciliation ? (
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
+                  <div className="flex items-center gap-2">
+                    <Badge variant="outline" data-testid="badge-reconciliation-status">
+                      {data.reconciliation.status.toUpperCase()}
+                    </Badge>
+                    <span>Attempt {data.reconciliation.attempt}</span>
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">Next poll</span>
+                    <div className="font-medium">{formatDate(data.reconciliation.nextPollAt)}</div>
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">Expires at</span>
+                    <div className="font-medium">{formatDate(data.reconciliation.expiresAt)}</div>
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">Last polled</span>
+                    <div className="font-medium">{formatDate(data.reconciliation.lastPolledAt)}</div>
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">Last state</span>
+                    <div className="font-medium">{data.reconciliation.lastStatus ?? "–"}</div>
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">Response code</span>
+                    <div className="font-medium">{data.reconciliation.lastResponseCode ?? "–"}</div>
+                  </div>
+                  <div className="sm:col-span-2">
+                    <span className="text-muted-foreground">Last error</span>
+                    <div className="font-medium whitespace-pre-wrap">{data.reconciliation.lastError ?? "–"}</div>
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">Completed at</span>
+                    <div className="font-medium">{formatDate(data.reconciliation.completedAt)}</div>
+                  </div>
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground">No reconciliation job recorded for this order.</p>
+              )}
+            </CardContent>
+          </Card>
+        </>
+      )}
+    </div>
+  );
+}

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -88,6 +88,10 @@ Both refactors improved maintainability but did not change **endpoint URLs** or 
    - PhonePe now sources its client credentials (`client_id`, `client_secret`, `client_version`), webhook basic-auth pair, redirect URL, and API hosts from the PAYAPP_* secret bundle while keeping the merchant ID in admin-managed database config, preventing drift between environments.
    - PhonePe API traffic now reuses a shared OAuth token manager that refreshes access tokens a few minutes before expiry and retries once on authentication failures, ensuring checkout, refund, and status checks remain seamless for buyers and support staff even during sustained traffic.
    - Host switching, sandbox VPAs, and simulator fixtures are documented in the [PhonePe Sandbox & Simulator guide](../README.md#phonepe-sandbox--simulator).
+7. **PhonePe Reconciliation Console**
+   - Support agents can open `/admin/phonepe-reconciliation?orderId={orderId}` to access a dedicated console backed by `GET /api/payments/admin/phonepe/orders/:orderId`.
+   - The endpoint re-queries PhonePe's order status API through the adapter, returning the latest gateway state, response code, and raw UPI instrument payload alongside masked identifiers stored on the order.
+   - The UI surfaces the active reconciliation job (status, attempt, next poll, errors) so teams can confirm whether polling is still progressing or has reached a terminal state before retrying a payment.
 
 ---
 

--- a/server/adapters/phonepe-adapter.ts
+++ b/server/adapters/phonepe-adapter.ts
@@ -362,6 +362,7 @@ export class PhonePeAdapter implements PaymentsAdapter {
             response.data?.paymentInstrument?.payerAddress,
           providerTransactionId: response.data?.transactionId,
           providerReferenceId: merchantTransactionId,
+          paymentInstrument: response.data?.paymentInstrument
         },
         
         createdAt: new Date(),


### PR DESCRIPTION
## Summary
- add a secured PhonePe admin reconciliation route that proxies order verification details from PhonePe and augments them with reconciliation metadata
- build an admin console page to query the new endpoint and display PhonePe status, UPI instrument details, and reconciliation job state
- add integration coverage for the route and admin UI, ensuring the page renders PhonePe status and UPI identifiers

## Testing
- npm run test
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dcceff1888832a946ffc801955a55f