### PR TITLE
Enforce admin-only access for order listings

### DIFF
--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -78,9 +78,10 @@ Both refactors improved maintainability but did not change **endpoint URLs** or 
    - `/api/admin/shipping-rules` in `server/routes/shipping.ts`, validated via Zod.  
    - Backed by `shippingRepository`.
 
-4. **Orders & Analytics**  
-   - `/api/admin/orders` in `server/routes/admin.ts`, backed by `ordersRepository`.  
-   - `/api/analytics` in `server/routes/analytics.ts`.  
+4. **Orders & Analytics**
+   - `/api/admin/orders` in `server/routes/admin.ts`, backed by `ordersRepository`.
+   - `/api/orders` read endpoints now enforce `requireAdmin`, keeping buyer history available through `/api/auth/orders`.
+   - `/api/analytics` in `server/routes/analytics.ts`.
    - Returned datasets and dashboards unchanged.
 
 5. **Settings**

--- a/server/routes/__tests__/orders-router.test.ts
+++ b/server/routes/__tests__/orders-router.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Request, Response, Router } from "express";
+import type { RequireAdminMiddleware } from "../types";
+
+const mockOrdersRepository = {
+  getOrders: vi.fn(),
+  getOrder: vi.fn(),
+  getCartItems: vi.fn(),
+  createOrder: vi.fn(),
+  createOrderItems: vi.fn(),
+  clearCart: vi.fn(),
+};
+
+const mockUsersRepository = {
+  getUserAddresses: vi.fn(),
+  createUserAddress: vi.fn(),
+  setPreferredAddress: vi.fn(),
+  updateUser: vi.fn(),
+};
+
+const mockOffersRepository = {
+  getOfferByCode: vi.fn(),
+  createOfferRedemption: vi.fn(),
+  incrementOfferUsage: vi.fn(),
+};
+
+const mockShippingRepository = {
+  calculateShippingCharge: vi.fn(),
+};
+
+vi.mock("../../storage", () => ({
+  ordersRepository: mockOrdersRepository,
+  usersRepository: mockUsersRepository,
+  offersRepository: mockOffersRepository,
+  shippingRepository: mockShippingRepository,
+}));
+
+const buildRouter = async (requireAdmin?: RequireAdminMiddleware) => {
+  const module = await import("../orders");
+  const defaultRequireAdmin: RequireAdminMiddleware = (_req, _res, next) => {
+    next();
+  };
+  return module.createOrdersRouter(requireAdmin ?? defaultRequireAdmin);
+};
+
+const getRouteLayer = (router: Router, method: "get", path: string) => {
+  const layer = router.stack.find(
+    (entry: any) => entry.route?.path === path && entry.route?.methods?.[method],
+  );
+  if (!layer) {
+    throw new Error(`Route ${method.toUpperCase()} ${path} not found`);
+  }
+  return layer;
+};
+
+const createMockResponse = () => {
+  const res: Partial<Response> & { statusCode?: number; jsonPayload?: any } = {};
+
+  res.status = vi.fn((code: number) => {
+    res.statusCode = code;
+    return res as Response;
+  }) as any;
+
+  res.json = vi.fn((payload: any) => {
+    res.jsonPayload = payload;
+    return res as Response;
+  }) as any;
+
+  return res as Response & { statusCode?: number; jsonPayload?: any };
+};
+
+describe("orders router admin access", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const invokeRouteStack = async (
+    router: Router,
+    path: string,
+    req: Partial<Request>,
+    res: Response,
+  ) => {
+    const layer = getRouteLayer(router, "get", path);
+    const [adminMiddleware, handler] = layer.route.stack;
+
+    await new Promise<void>((resolve, reject) => {
+      try {
+        adminMiddleware.handle(req, res, async () => {
+          try {
+            await handler.handle(req, res, () => {});
+            resolve();
+          } catch (error) {
+            reject(error);
+          }
+        });
+      } catch (error) {
+        reject(error);
+      }
+    });
+  };
+
+  it("returns 401 when non-admins request the order list", async () => {
+    const requireAdminMock = vi.fn((_req: Request, res: Response) => {
+      res.status(401).json({ message: "Admin access required" });
+    });
+
+    const router = await buildRouter(requireAdminMock);
+    const layer = getRouteLayer(router, "get", "/");
+    const res = createMockResponse();
+    const req = { query: {} } as Request;
+
+    await layer.route.stack[0].handle(req, res, () => {});
+
+    expect(requireAdminMock).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ message: "Admin access required" });
+    expect(mockOrdersRepository.getOrders).not.toHaveBeenCalled();
+  });
+
+  it("allows admins to retrieve the order list", async () => {
+    const requireAdminMock = vi.fn((_req: Request, _res: Response, next: () => void) => {
+      next();
+    });
+    const router = await buildRouter(requireAdminMock);
+    const res = createMockResponse();
+    const req = { query: {} } as Request;
+
+    const orders = [{ id: "order-1" }];
+    mockOrdersRepository.getOrders.mockResolvedValueOnce(orders);
+
+    await invokeRouteStack(router, "/", req, res);
+
+    expect(requireAdminMock).toHaveBeenCalledTimes(1);
+    expect(mockOrdersRepository.getOrders).toHaveBeenCalledWith(undefined);
+    expect(res.json).toHaveBeenCalledWith(orders);
+  });
+
+  it("returns 401 when non-admins request an order by id", async () => {
+    const requireAdminMock = vi.fn((_req: Request, res: Response) => {
+      res.status(401).json({ message: "Admin access required" });
+    });
+
+    const router = await buildRouter(requireAdminMock);
+    const layer = getRouteLayer(router, "get", "/:id");
+    const res = createMockResponse();
+    const req = { params: { id: "order-1" } } as unknown as Request;
+
+    await layer.route.stack[0].handle(req, res, () => {});
+
+    expect(requireAdminMock).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ message: "Admin access required" });
+    expect(mockOrdersRepository.getOrder).not.toHaveBeenCalled();
+  });
+
+  it("allows admins to fetch a single order", async () => {
+    const requireAdminMock = vi.fn((_req: Request, _res: Response, next: () => void) => {
+      next();
+    });
+
+    const router = await buildRouter(requireAdminMock);
+    const res = createMockResponse();
+    const req = { params: { id: "order-1" } } as unknown as Request;
+
+    const order = { id: "order-1" };
+    mockOrdersRepository.getOrder.mockResolvedValueOnce(order);
+
+    await invokeRouteStack(router, "/:id", req, res);
+
+    expect(requireAdminMock).toHaveBeenCalledTimes(1);
+    expect(mockOrdersRepository.getOrder).toHaveBeenCalledWith("order-1");
+    expect(res.json).toHaveBeenCalledWith(order);
+  });
+});

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -104,7 +104,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.use("/api/products", createProductsRouter(requireAdmin));
   app.use("/api/cart", createCartRouter());
   app.use("/api/offers", createOffersRouter(requireAdmin));
-  app.use("/api/orders", createOrdersRouter());
+  app.use("/api/orders", createOrdersRouter(requireAdmin));
   app.use("/api/auth", createAuthRouter());
   app.use("/api/otp", createLegacyOtpRouter());
   app.use("/api/objects", createObjectStorageRouter(objectStorageService));

--- a/server/routes/orders.ts
+++ b/server/routes/orders.ts
@@ -11,9 +11,9 @@ import {
   insertUserAddressSchema,
   insertUserSchema,
 } from "@shared/schema";
-import type { SessionRequest } from "./types";
+import type { RequireAdminMiddleware, SessionRequest } from "./types";
 
-export function createOrdersRouter() {
+export function createOrdersRouter(requireAdmin: RequireAdminMiddleware) {
   const router = Router();
 
   const orderCreationSchema = z.object({
@@ -220,7 +220,7 @@ export function createOrdersRouter() {
     }
   });
 
-  router.get("/", async (req, res) => {
+  router.get("/", requireAdmin, async (req: SessionRequest, res) => {
     try {
       const filters = {
         status: req.query.status as string,
@@ -242,7 +242,7 @@ export function createOrdersRouter() {
     }
   });
 
-  router.get("/:id", async (req, res) => {
+  router.get("/:id", requireAdmin, async (req: SessionRequest, res) => {
     try {
       const order = await ordersRepository.getOrder(req.params.id);
       if (!order) {


### PR DESCRIPTION
## Summary
- require admin authorization for order listing/detail endpoints while leaving buyer history under /api/auth/orders
- thread the requireAdmin middleware into the orders router and document the tightened access control
- add vitest coverage confirming non-admin requests are rejected and admins receive data

## Testing
- npm run check
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd39433f64832ab5d04e8eafbf6bfb