### PR TITLE
Secure user passwords with bcrypt hashing

### DIFF
--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -22,9 +22,10 @@ Both refactors improved maintainability but did not change **endpoint URLs** or 
    - Implemented in `server/routes/cart.ts`, using `ordersRepository` cart helpers.  
    - Persistence, validation, and session handling unchanged.
 
-3. **Authenticate with OTP**  
-   - `POST /api/auth/send-otp`, `POST /api/auth/login` in `server/routes/auth.ts`, backed by `usersRepository`.  
+3. **Authenticate with OTP**
+   - `POST /api/auth/send-otp`, `POST /api/auth/login` in `server/routes/auth.ts`, backed by `usersRepository`.
    - Successful login attaches buyer context to session.
+   - Password-based fallbacks (where configured for returning buyers) now hash credentials with bcrypt and transparently upgrade legacy plaintext entries the first time a buyer logs in, so there is no change to the checkout experience.
 
 4. **Manage Addresses**  
    - `/api/auth/addresses` endpoints (create/list/update/delete) in `server/routes/auth.ts`.  
@@ -65,9 +66,10 @@ Both refactors improved maintainability but did not change **endpoint URLs** or 
 ---
 
 ## Administrator Flow
-1. **Authentication**  
-   - `/api/admin/login` handled in `server/routes/admin.ts`, backed by `usersRepository`.  
+1. **Authentication**
+   - `/api/admin/login` handled in `server/routes/admin.ts`, backed by `usersRepository`.
    - `requireAdmin` middleware from `server/routes/index.ts` protects routes.
+   - Admin passwords are now stored as bcrypt hashes. Legacy plaintext credentials are rehashed automatically on successful login, keeping the dashboard sign-in flow unchanged while hardening storage.
 
 2. **Product & Offer Management**  
    - CRUD operations under `/api/products` and `/api/admin/offers`.  
@@ -102,8 +104,9 @@ Both refactors improved maintainability but did not change **endpoint URLs** or 
 ---
 
 ## Influencer Flow
-1. **Authentication**  
+1. **Authentication**
    - Influencer login/profile handled by `server/routes/influencers.ts`, backed by `usersRepository`.
+   - Password authentication now verifies bcrypt hashes and upgrades any remaining plaintext passwords during the next successful login without altering the influencer portal UX.
 
 2. **Lifecycle Management**  
    - Admin creates/deactivates influencers using the same routes, now backed by `usersRepository`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "@uppy/core": "^5.0.0",
         "@uppy/dashboard": "^5.0.0",
         "@uppy/react": "^5.0.0",
+        "bcryptjs": "^3.0.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -6553,6 +6554,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
+      "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
     },
     "node_modules/bidi-js": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@uppy/core": "^5.0.0",
     "@uppy/dashboard": "^5.0.0",
     "@uppy/react": "^5.0.0",
+    "bcryptjs": "^3.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/server/storage/__tests__/users-repository.test.ts
+++ b/server/storage/__tests__/users-repository.test.ts
@@ -1,0 +1,199 @@
+import bcrypt from "bcryptjs";
+import { describe, expect, it, vi } from "vitest";
+
+import { admins, influencers, users } from "@shared/schema";
+
+const mockedDb = vi.hoisted(() => ({
+  select: vi.fn(),
+  update: vi.fn(),
+  insert: vi.fn(),
+  delete: vi.fn(),
+}));
+
+vi.mock("../../db", () => ({
+  db: mockedDb,
+}));
+
+import { UsersRepository } from "../users";
+
+function createMockDb() {
+  const selectWhere = vi
+    .fn<[table: unknown, condition: unknown], Promise<any[]>>()
+    .mockResolvedValue([]);
+  const updateWhere = vi
+    .fn<[table: unknown, values: unknown, condition: unknown], Promise<any>>()
+    .mockResolvedValue([]);
+
+  const mockDb = {
+    select: vi.fn(() => ({
+      from: vi.fn((table: unknown) => ({
+        where: (condition: unknown) => selectWhere(table, condition),
+      })),
+    })),
+    update: vi.fn((table: unknown) => ({
+      set: vi.fn((values: unknown) => ({
+        where: (condition: unknown) => updateWhere(table, values, condition),
+      })),
+    })),
+  } as const;
+
+  return {
+    mockDb:
+      mockDb as unknown as ConstructorParameters<typeof UsersRepository>[0],
+    selectWhere,
+    updateWhere,
+  };
+}
+
+describe("UsersRepository authentication hashing", () => {
+  it("authenticates hashed admin passwords without rehashing", async () => {
+    const hashedPassword = await bcrypt.hash("secret", 12);
+    const { mockDb, selectWhere, updateWhere } = createMockDb();
+    selectWhere.mockImplementation(async (table) => {
+      if (table === admins) {
+        return [
+          {
+            id: "admin-1",
+            phone: "+1000000000",
+            password: hashedPassword,
+            isActive: true,
+          },
+        ];
+      }
+      return [];
+    });
+
+    const repository = new UsersRepository(mockDb);
+
+    const result = await repository.authenticateAdmin("+1000000000", "secret");
+
+    expect(result?.id).toBe("admin-1");
+    expect(updateWhere).not.toHaveBeenCalled();
+  });
+
+  it("rehashes legacy plaintext admin passwords on login", async () => {
+    const { mockDb, selectWhere, updateWhere } = createMockDb();
+    selectWhere.mockImplementation(async (table) => {
+      if (table === admins) {
+        return [
+          {
+            id: "admin-2",
+            phone: "+1999999999",
+            password: "legacy",
+            isActive: true,
+          },
+        ];
+      }
+      return [];
+    });
+
+    const repository = new UsersRepository(mockDb);
+
+    const result = await repository.authenticateAdmin("+1999999999", "legacy");
+
+    expect(result?.id).toBe("admin-2");
+    expect(updateWhere).toHaveBeenCalledTimes(1);
+    const [, values] = updateWhere.mock.calls[0];
+    expect(values.password).toMatch(/^\$2[aby]\$/);
+    expect(values.updatedAt).toBeInstanceOf(Date);
+    expect(result?.password).toMatch(/^\$2[aby]\$/);
+  });
+
+  it("authenticates hashed influencer passwords", async () => {
+    const hashedPassword = await bcrypt.hash("opensesame", 12);
+    const { mockDb, selectWhere, updateWhere } = createMockDb();
+    selectWhere.mockImplementation(async (table) => {
+      if (table === influencers) {
+        return [
+          {
+            id: "influencer-1",
+            phone: "+1888888888",
+            password: hashedPassword,
+            isActive: true,
+          },
+        ];
+      }
+      return [];
+    });
+
+    const repository = new UsersRepository(mockDb);
+
+    const result = await repository.authenticateInfluencer("+1888888888", "opensesame");
+
+    expect(result?.id).toBe("influencer-1");
+    expect(updateWhere).not.toHaveBeenCalled();
+  });
+
+  it("authenticates hashed buyer passwords", async () => {
+    const hashedPassword = await bcrypt.hash("buyerpass", 12);
+    const { mockDb, selectWhere, updateWhere } = createMockDb();
+    selectWhere.mockImplementation(async (table) => {
+      if (table === users) {
+        return [
+          {
+            id: "user-1",
+            phone: "+1777777777",
+            password: hashedPassword,
+          },
+        ];
+      }
+      return [];
+    });
+
+    const repository = new UsersRepository(mockDb);
+
+    const result = await repository.authenticateUser("+1777777777", "buyerpass");
+
+    expect(result?.id).toBe("user-1");
+    expect(updateWhere).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid passwords once hashes are stored", async () => {
+    const hashedPassword = await bcrypt.hash("correct", 12);
+    const { mockDb, selectWhere, updateWhere } = createMockDb();
+    selectWhere.mockImplementation(async (table) => {
+      if (table === admins) {
+        return [
+          {
+            id: "admin-3",
+            phone: "+1666666666",
+            password: hashedPassword,
+            isActive: true,
+          },
+        ];
+      }
+      return [];
+    });
+
+    const repository = new UsersRepository(mockDb);
+
+    const result = await repository.authenticateAdmin("+1666666666", "incorrect");
+
+    expect(result).toBeNull();
+    expect(updateWhere).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid influencer passwords once hashes are stored", async () => {
+    const hashedPassword = await bcrypt.hash("goodpass", 12);
+    const { mockDb, selectWhere } = createMockDb();
+    selectWhere.mockImplementation(async (table) => {
+      if (table === influencers) {
+        return [
+          {
+            id: "influencer-2",
+            phone: "+1555555555",
+            password: hashedPassword,
+            isActive: true,
+          },
+        ];
+      }
+      return [];
+    });
+
+    const repository = new UsersRepository(mockDb);
+
+    const result = await repository.authenticateInfluencer("+1555555555", "badpass");
+
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- integrate bcrypt-based hashing in the users repository for admin, influencer, and buyer credentials, including hash-on-create/update and migration on login
- add unit coverage verifying authentication success, plaintext migration, and invalid password handling after hashing
- document that buyer/admin/influencer journeys now store passwords as hashes

## Testing
- npm run check
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd39bccbf4832a8f9caf3936a89335