### PR TITLE
Enforce cart quantity validation and stock clamps

### DIFF
--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -14,13 +14,16 @@ Both refactors improved maintainability but did not change **endpoint URLs** or 
    - `GET /api/products` and `GET /api/products/:id` now handled by `server/routes/products.ts`, backed by `productsRepository`.
    - API responses unchanged.
 
-2. **Manage Cart**  
-   - Endpoints:  
-     - `POST /api/cart/items`  
-     - `PATCH /api/cart/items/:id`  
-     - `DELETE /api/cart/items/:id`  
-   - Implemented in `server/routes/cart.ts`, using `ordersRepository` cart helpers.  
-   - Persistence, validation, and session handling unchanged.
+2. **Manage Cart**
+   - Endpoints:
+     - `GET /api/cart`
+     - `POST /api/cart/add`
+     - `PATCH /api/cart/:productId`
+     - `DELETE /api/cart/:productId`
+     - `DELETE /api/cart/clear`
+   - Implemented in `server/routes/cart.ts`, using `ordersRepository` cart helpers.
+   - The API now rejects non-integer or out-of-range quantities (`< 1` or `> 10`) with a `400` response before touching storage, ensuring storefront and admin flows receive immediate feedback on invalid updates.
+   - `ordersRepository` clamps persisted quantities to the lower of product stock and the per-order maximum, so concurrent updates never push cart lines past available inventory.
 
 3. **Authenticate with OTP**  
    - `POST /api/auth/send-otp`, `POST /api/auth/login` in `server/routes/auth.ts`, backed by `usersRepository`.  

--- a/server/routes/__tests__/cart-router.test.ts
+++ b/server/routes/__tests__/cart-router.test.ts
@@ -1,0 +1,163 @@
+import type { Request, Response, Router } from "express";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createCartRouter } from "../cart";
+import type { SessionRequest } from "../types";
+
+const getCartItemsMock = vi.hoisted(() => vi.fn());
+const addToCartMock = vi.hoisted(() => vi.fn());
+const updateCartItemMock = vi.hoisted(() => vi.fn());
+const removeFromCartMock = vi.hoisted(() => vi.fn());
+const clearCartMock = vi.hoisted(() => vi.fn());
+
+const MIN_CART_ITEM_QUANTITY = vi.hoisted(() => 1);
+const MAX_CART_ITEM_QUANTITY = vi.hoisted(() => 10);
+
+const CartQuantityErrorMock = vi.hoisted(
+  () =>
+    class CartQuantityError extends Error {
+      constructor(message?: string) {
+        super(message);
+        this.name = "CartQuantityError";
+      }
+    },
+);
+
+const CartQuantityError = CartQuantityErrorMock;
+
+vi.mock("../../storage", () => ({
+  ordersRepository: {
+    getCartItems: getCartItemsMock,
+    addToCart: addToCartMock,
+    updateCartItem: updateCartItemMock,
+    removeFromCart: removeFromCartMock,
+    clearCart: clearCartMock,
+  },
+}));
+
+vi.mock("../../storage/orders", () => ({
+  CartQuantityError: CartQuantityErrorMock,
+  MIN_CART_ITEM_QUANTITY,
+  MAX_CART_ITEM_QUANTITY,
+}));
+
+const buildRouter = () => createCartRouter();
+
+const getRouteHandler = (
+  router: Router,
+  method: "get" | "post" | "patch" | "delete",
+  path: string,
+) => {
+  const layer = router.stack.find(
+    (entry: any) => entry.route?.path === path && entry.route?.methods?.[method],
+  );
+
+  if (!layer) {
+    throw new Error(`Route ${method.toUpperCase()} ${path} not found`);
+  }
+
+  const handles = layer.route.stack;
+  const target = handles[handles.length - 1];
+  return target.handle as (req: Request, res: Response, next: () => void) => Promise<void> | void;
+};
+
+const buildResponse = () => {
+  const res: Partial<Response> & { statusCode?: number; jsonPayload?: any } = {
+    statusCode: 200,
+  };
+
+  res.status = vi.fn((code: number) => {
+    res.statusCode = code;
+    return res as Response;
+  }) as any;
+
+  res.json = vi.fn((payload: any) => {
+    res.jsonPayload = payload;
+    return res as Response;
+  }) as any;
+
+  return res as Response & { statusCode: number; jsonPayload: any };
+};
+
+const buildRequest = (overrides: Partial<SessionRequest> = {}): SessionRequest => {
+  return {
+    body: {},
+    params: {},
+    session: { sessionId: "session-1" },
+    ...overrides,
+  } as SessionRequest;
+};
+
+beforeEach(() => {
+  getCartItemsMock.mockReset();
+  addToCartMock.mockReset();
+  updateCartItemMock.mockReset();
+  removeFromCartMock.mockReset();
+  clearCartMock.mockReset();
+});
+
+describe("cart router quantity validation", () => {
+  it("rejects negative quantities when adding to the cart", async () => {
+    const router = buildRouter();
+    const handler = getRouteHandler(router, "post", "/add");
+    const req = buildRequest({ body: { productId: "product-1", quantity: -1 } });
+    const res = buildResponse();
+
+    await handler(req as unknown as Request, res, () => {});
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.jsonPayload.message).toContain("Quantity");
+    expect(addToCartMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects quantities above the configured maximum", async () => {
+    const router = buildRouter();
+    const handler = getRouteHandler(router, "post", "/add");
+    const req = buildRequest({
+      body: { productId: "product-1", quantity: MAX_CART_ITEM_QUANTITY + 1 },
+    });
+    const res = buildResponse();
+
+    await handler(req as unknown as Request, res, () => {});
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.jsonPayload.message).toContain(`${MIN_CART_ITEM_QUANTITY} and ${MAX_CART_ITEM_QUANTITY}`);
+    expect(addToCartMock).not.toHaveBeenCalled();
+  });
+
+  it("updates the cart when the requested quantity is valid", async () => {
+    const router = buildRouter();
+    const handler = getRouteHandler(router, "patch", "/:productId");
+    const expectedItem = { id: "cart-1", productId: "product-1", quantity: 3 };
+    updateCartItemMock.mockResolvedValue(expectedItem);
+
+    const req = buildRequest({
+      params: { productId: "product-1" },
+      body: { quantity: 3 },
+    });
+    const res = buildResponse();
+
+    await handler(req as unknown as Request, res, () => {});
+
+    expect(updateCartItemMock).toHaveBeenCalledWith("session-1", "product-1", 3);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.jsonPayload).toEqual(expectedItem);
+  });
+
+  it("returns 400 when repository clamps due to stock issues", async () => {
+    const router = buildRouter();
+    const handler = getRouteHandler(router, "patch", "/:productId");
+    updateCartItemMock.mockRejectedValue(new CartQuantityError("Product is out of stock"));
+
+    const req = buildRequest({
+      params: { productId: "product-1" },
+      body: { quantity: 2 },
+    });
+    const res = buildResponse();
+
+    await handler(req as unknown as Request, res, () => {});
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.jsonPayload.message).toBe("Product is out of stock");
+  });
+});

--- a/server/routes/cart.ts
+++ b/server/routes/cart.ts
@@ -1,10 +1,33 @@
 import { Router } from "express";
 
 import { ordersRepository } from "../storage";
+import {
+  CartQuantityError,
+  MAX_CART_ITEM_QUANTITY,
+  MIN_CART_ITEM_QUANTITY,
+} from "../storage/orders";
 import type { SessionRequest } from "./types";
 
 export function createCartRouter() {
   const router = Router();
+
+  const parseQuantity = (value: unknown): number | null => {
+    if (value === undefined || value === null) {
+      return null;
+    }
+
+    const quantity = typeof value === "string" && value.trim() !== "" ? Number(value) : Number(value);
+
+    if (!Number.isInteger(quantity)) {
+      return null;
+    }
+
+    if (quantity < MIN_CART_ITEM_QUANTITY || quantity > MAX_CART_ITEM_QUANTITY) {
+      return null;
+    }
+
+    return quantity;
+  };
 
   router.get("/", async (req: SessionRequest, res) => {
     try {
@@ -18,7 +41,20 @@ export function createCartRouter() {
 
   router.post("/add", async (req: SessionRequest, res) => {
     try {
-      const { productId, quantity = 1 } = req.body;
+      const { productId } = req.body;
+      const requestedQuantity = req.body.quantity ?? 1;
+      const quantity = parseQuantity(requestedQuantity);
+
+      if (typeof productId !== "string" || !productId) {
+        return res.status(400).json({ message: "Product ID is required" });
+      }
+
+      if (quantity === null) {
+        return res.status(400).json({
+          message: `Quantity must be an integer between ${MIN_CART_ITEM_QUANTITY} and ${MAX_CART_ITEM_QUANTITY}`,
+        });
+      }
+
       const cartItem = await ordersRepository.addToCart(
         req.session.sessionId!,
         productId,
@@ -27,13 +63,23 @@ export function createCartRouter() {
       res.json(cartItem);
     } catch (error) {
       console.error("Error adding to cart:", error);
+      if (error instanceof CartQuantityError) {
+        return res.status(400).json({ message: error.message });
+      }
       res.status(500).json({ message: "Failed to add to cart" });
     }
   });
 
   router.patch("/:productId", async (req: SessionRequest, res) => {
     try {
-      const { quantity } = req.body;
+      const quantity = parseQuantity(req.body.quantity);
+
+      if (quantity === null) {
+        return res.status(400).json({
+          message: `Quantity must be an integer between ${MIN_CART_ITEM_QUANTITY} and ${MAX_CART_ITEM_QUANTITY}`,
+        });
+      }
+
       const cartItem = await ordersRepository.updateCartItem(
         req.session.sessionId!,
         req.params.productId,
@@ -42,6 +88,9 @@ export function createCartRouter() {
       res.json(cartItem);
     } catch (error) {
       console.error("Error updating cart item:", error);
+      if (error instanceof CartQuantityError) {
+        return res.status(400).json({ message: error.message });
+      }
       res.status(500).json({ message: "Failed to update cart item" });
     }
   });

--- a/server/storage/__tests__/orders-repository.test.ts
+++ b/server/storage/__tests__/orders-repository.test.ts
@@ -1,10 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { phonePeIdentifierFixture } from "../../../shared/__fixtures__/upi";
+import { cartItems, products } from "../../../shared/schema";
 
 const findFirstMock = vi.hoisted(() => vi.fn());
+const selectMock = vi.hoisted(() => vi.fn());
+const insertMock = vi.hoisted(() => vi.fn());
+const updateMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../../db", () => ({
   db: {
+    select: selectMock,
+    insert: insertMock,
+    update: updateMock,
+    delete: vi.fn(),
     query: {
       orders: {
         findFirst: findFirstMock,
@@ -14,9 +22,59 @@ vi.mock("../../db", () => ({
   },
 }));
 
-import { OrdersRepository } from "../orders";
+import { CartQuantityError, OrdersRepository } from "../orders";
 
 const repository = new OrdersRepository();
+
+let selectResponses: Map<any, any[]>;
+let insertValuesArg: any;
+let insertReturnValue: any[];
+let updateSetArg: any;
+let updateReturnValue: any[];
+
+beforeEach(() => {
+  findFirstMock.mockReset();
+  selectMock.mockReset();
+  insertMock.mockReset();
+  updateMock.mockReset();
+
+  selectResponses = new Map();
+  insertValuesArg = undefined;
+  insertReturnValue = [];
+  updateSetArg = undefined;
+  updateReturnValue = [];
+
+  const createSelectChain = (table: any) => {
+    const chain: any = {};
+    chain.where = vi.fn(async () => selectResponses.get(table) ?? []);
+    chain.innerJoin = vi.fn(() => chain);
+    return chain;
+  };
+
+  selectMock.mockImplementation(() => ({
+    from: (table: any) => createSelectChain(table),
+  }));
+
+  insertMock.mockImplementation(() => ({
+    values: (valuesArg: any) => {
+      insertValuesArg = valuesArg;
+      return {
+        returning: vi.fn(async () => insertReturnValue),
+      };
+    },
+  }));
+
+  updateMock.mockImplementation(() => ({
+    set: (setArg: any) => {
+      updateSetArg = setArg;
+      return {
+        where: () => ({
+          returning: vi.fn(async () => updateReturnValue),
+        }),
+      };
+    },
+  }));
+});
 
 describe("OrdersRepository.getOrderWithPayments", () => {
   beforeEach(() => {
@@ -65,5 +123,198 @@ describe("OrdersRepository.getOrderWithPayments", () => {
     expect(payment?.upiPayerHandle).toBe(phonePeIdentifierFixture.maskedVpa);
     expect(payment?.upiUtr).toBe(phonePeIdentifierFixture.maskedUtr);
     expect(payment?.upiInstrumentVariant).toBe(phonePeIdentifierFixture.variant);
+  });
+});
+
+describe("OrdersRepository.addToCart", () => {
+  it("clamps additions to available stock", async () => {
+    const existingItem = {
+      id: "cart-1",
+      sessionId: "session-1",
+      productId: "product-1",
+      quantity: 4,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    selectResponses.set(products, [
+      {
+        id: "product-1",
+        isActive: true,
+        stock: 5,
+      },
+    ]);
+    selectResponses.set(cartItems, [existingItem]);
+
+    updateReturnValue = [
+      {
+        ...existingItem,
+        quantity: 5,
+        updatedAt: new Date(),
+      },
+    ];
+
+    const result = await repository.addToCart("session-1", "product-1", 3);
+
+    expect(updateSetArg.quantity).toBe(5);
+    expect(result.quantity).toBe(5);
+  });
+
+  it("caps combined quantity at the per-order maximum", async () => {
+    const existingItem = {
+      id: "cart-1",
+      sessionId: "session-1",
+      productId: "product-1",
+      quantity: 9,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    selectResponses.set(products, [
+      {
+        id: "product-1",
+        isActive: true,
+        stock: 50,
+      },
+    ]);
+    selectResponses.set(cartItems, [existingItem]);
+
+    updateReturnValue = [
+      {
+        ...existingItem,
+        quantity: 10,
+        updatedAt: new Date(),
+      },
+    ];
+
+    const result = await repository.addToCart("session-1", "product-1", 5);
+
+    expect(updateSetArg.quantity).toBe(10);
+    expect(result.quantity).toBe(10);
+  });
+
+  it("inserts a new cart item when none exists", async () => {
+    selectResponses.set(products, [
+      {
+        id: "product-1",
+        isActive: true,
+        stock: 2,
+      },
+    ]);
+    selectResponses.set(cartItems, []);
+
+    insertReturnValue = [
+      {
+        id: "cart-1",
+        sessionId: "session-1",
+        productId: "product-1",
+        quantity: 2,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+
+    const result = await repository.addToCart("session-1", "product-1", 5);
+
+    expect(insertValuesArg).toMatchObject({
+      sessionId: "session-1",
+      productId: "product-1",
+      quantity: 2,
+    });
+    expect(result.quantity).toBe(2);
+  });
+
+  it("throws when product is out of stock", async () => {
+    selectResponses.set(products, [
+      {
+        id: "product-1",
+        isActive: true,
+        stock: 0,
+      },
+    ]);
+    selectResponses.set(cartItems, []);
+
+    await expect(repository.addToCart("session-1", "product-1", 1)).rejects.toBeInstanceOf(CartQuantityError);
+  });
+});
+
+describe("OrdersRepository.updateCartItem", () => {
+  it("clamps updates to available stock", async () => {
+    const existingItem = {
+      id: "cart-1",
+      sessionId: "session-1",
+      productId: "product-1",
+      quantity: 1,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    selectResponses.set(products, [
+      {
+        id: "product-1",
+        isActive: true,
+        stock: 3,
+      },
+    ]);
+    selectResponses.set(cartItems, [existingItem]);
+
+    updateReturnValue = [
+      {
+        ...existingItem,
+        quantity: 3,
+        updatedAt: new Date(),
+      },
+    ];
+
+    const result = await repository.updateCartItem("session-1", "product-1", 5);
+
+    expect(updateSetArg.quantity).toBe(3);
+    expect(result.quantity).toBe(3);
+  });
+
+  it("returns the updated cart item when the quantity is valid", async () => {
+    const existingItem = {
+      id: "cart-1",
+      sessionId: "session-1",
+      productId: "product-1",
+      quantity: 1,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    selectResponses.set(products, [
+      {
+        id: "product-1",
+        isActive: true,
+        stock: 5,
+      },
+    ]);
+    selectResponses.set(cartItems, [existingItem]);
+
+    updateReturnValue = [
+      {
+        ...existingItem,
+        quantity: 2,
+        updatedAt: new Date(),
+      },
+    ];
+
+    const result = await repository.updateCartItem("session-1", "product-1", 2);
+
+    expect(updateSetArg.quantity).toBe(2);
+    expect(result.quantity).toBe(2);
+  });
+
+  it("throws when the cart item does not exist", async () => {
+    selectResponses.set(products, [
+      {
+        id: "product-1",
+        isActive: true,
+        stock: 5,
+      },
+    ]);
+    selectResponses.set(cartItems, []);
+
+    await expect(repository.updateCartItem("session-1", "product-1", 2)).rejects.toBeInstanceOf(CartQuantityError);
   });
 });

--- a/server/storage/orders.ts
+++ b/server/storage/orders.ts
@@ -18,6 +18,16 @@ import type { AbandonedCart } from "@/lib/types";
 import { db } from "../db";
 import { eq, and, desc, sql, gte, lt } from "drizzle-orm";
 
+export const MIN_CART_ITEM_QUANTITY = 1;
+export const MAX_CART_ITEM_QUANTITY = 10;
+
+export class CartQuantityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CartQuantityError";
+  }
+}
+
 export class OrdersRepository {
   async getOrders(filters?: {
     status?: string;
@@ -203,35 +213,53 @@ export class OrdersRepository {
   }
 
   async addToCart(sessionId: string, productId: string, quantity: number): Promise<CartItem> {
-    const existingItem = await db
-      .select()
-      .from(cartItems)
-      .where(and(eq(cartItems.sessionId, sessionId), eq(cartItems.productId, productId)));
+    const product = await this.requireActiveProduct(productId);
+    const existingItem = await this.findCartItem(sessionId, productId);
 
-    if (existingItem.length > 0) {
+    const desiredQuantity = (existingItem?.quantity ?? 0) + quantity;
+    const clampedQuantity = this.clampQuantity(desiredQuantity, product.stock);
+
+    if (existingItem) {
+      if (existingItem.quantity === clampedQuantity) {
+        return existingItem;
+      }
+
       const [updatedItem] = await db
         .update(cartItems)
         .set({
-          quantity: existingItem[0].quantity + quantity,
+          quantity: clampedQuantity,
           updatedAt: new Date(),
         })
-        .where(eq(cartItems.id, existingItem[0].id))
+        .where(eq(cartItems.id, existingItem.id))
         .returning();
       return updatedItem;
     }
 
     const [newItem] = await db
       .insert(cartItems)
-      .values({ sessionId, productId, quantity })
+      .values({ sessionId, productId, quantity: clampedQuantity })
       .returning();
     return newItem;
   }
 
   async updateCartItem(sessionId: string, productId: string, quantity: number): Promise<CartItem> {
+    const product = await this.requireActiveProduct(productId);
+    const existingItem = await this.findCartItem(sessionId, productId);
+
+    if (!existingItem) {
+      throw new CartQuantityError("Cart item not found");
+    }
+
+    const clampedQuantity = this.clampQuantity(quantity, product.stock);
+
+    if (existingItem.quantity === clampedQuantity) {
+      return existingItem;
+    }
+
     const [updatedItem] = await db
       .update(cartItems)
-      .set({ quantity, updatedAt: new Date() })
-      .where(and(eq(cartItems.sessionId, sessionId), eq(cartItems.productId, productId)))
+      .set({ quantity: clampedQuantity, updatedAt: new Date() })
+      .where(eq(cartItems.id, existingItem.id))
       .returning();
     return updatedItem;
   }
@@ -335,5 +363,43 @@ export class OrdersRepository {
       ordersCompleted: ordersCompleted || 0,
       conversionRate,
     };
+  }
+
+  private async requireActiveProduct(productId: string): Promise<Product> {
+    const [product] = await db
+      .select()
+      .from(products)
+      .where(and(eq(products.id, productId), eq(products.isActive, true)));
+
+    if (!product) {
+      throw new CartQuantityError("Product not available");
+    }
+
+    return product;
+  }
+
+  private async findCartItem(sessionId: string, productId: string): Promise<CartItem | undefined> {
+    const [cartItem] = await db
+      .select()
+      .from(cartItems)
+      .where(and(eq(cartItems.sessionId, sessionId), eq(cartItems.productId, productId)));
+
+    return cartItem;
+  }
+
+  private clampQuantity(requestedQuantity: number, productStock: number): number {
+    const maxAvailable = Math.min(productStock, MAX_CART_ITEM_QUANTITY);
+
+    if (maxAvailable < MIN_CART_ITEM_QUANTITY) {
+      throw new CartQuantityError("Product is out of stock");
+    }
+
+    const clamped = Math.min(Math.max(requestedQuantity, MIN_CART_ITEM_QUANTITY), maxAvailable);
+
+    if (clamped < MIN_CART_ITEM_QUANTITY) {
+      throw new CartQuantityError("Quantity must be at least 1");
+    }
+
+    return clamped;
   }
 }


### PR DESCRIPTION
## Summary
- validate cart quantity payloads in the cart router and surface friendly 400 errors for bad input or stock issues
- clamp cart persistence in the orders repository to respect product stock and max-per-item limits while exporting reusable guardrails
- cover the new validation and clamping paths with repository and router tests, and document the cart flow updates in the user journey guide

## Testing
- npm run check
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd39c02d30832abeb5e1423c97811b