### PR TITLE
Refine navigation links for header and footer

### DIFF
--- a/client/src/components/layout/footer.tsx
+++ b/client/src/components/layout/footer.tsx
@@ -1,44 +1,41 @@
-import { useLocation } from "wouter";
-import { Button } from "@/components/ui/button";
+import { Link } from "wouter";
 
 export default function Footer() {
-  const [location, setLocation] = useLocation();
-
   return (
     <footer className="bg-gray-50 border-t border-gray-200 mt-auto">
       <div className="max-w-4xl mx-auto px-4 py-3">
         <div className="flex flex-wrap items-center justify-center gap-4 text-xs text-gray-500">
-          <button
-            onClick={() => setLocation("/terms-of-service")}
-            className="hover:text-gray-700 transition-colors"
+          <Link
+            href="/terms-of-service"
+            className="rounded hover:text-gray-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-50"
             data-testid="link-terms-of-service"
           >
             Terms of service
-          </button>
+          </Link>
           <span>•</span>
-          <button
-            onClick={() => setLocation("/refund-policy")}
-            className="hover:text-gray-700 transition-colors"
+          <Link
+            href="/refund-policy"
+            className="rounded hover:text-gray-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-50"
             data-testid="link-refund-policy"
           >
             Refund Return cancellation policy
-          </button>
+          </Link>
           <span>•</span>
-          <button
-            onClick={() => setLocation("/admin")}
-            className="hover:text-gray-700 transition-colors"
+          <Link
+            href="/admin"
+            className="rounded hover:text-gray-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-50"
             data-testid="button-admin"
           >
             Admin
-          </button>
+          </Link>
           <span>•</span>
-          <button
-            onClick={() => setLocation("/influencer")}
-            className="hover:text-gray-700 transition-colors"
+          <Link
+            href="/influencer"
+            className="rounded hover:text-gray-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-50"
             data-testid="button-influencer"
           >
             Influencer
-          </button>
+          </Link>
           <span>•</span>
           <span>contact: +919890894335/support@kanhaa.com</span>
         </div>

--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -1,37 +1,43 @@
+import { Link } from "wouter";
+
 import { useCart } from "@/hooks/use-cart";
-import { useLocation } from "wouter";
 import UserMenu from "./user-menu";
 
 export default function Header() {
-  const [location, setLocation] = useLocation();
   const { cartItems } = useCart();
-  
+
   const cartCount = cartItems?.reduce((sum, item) => sum + item.quantity, 0) || 0;
 
   return (
     <header className="bg-white shadow-sm sticky top-0 z-50">
       <div className="max-w-4xl mx-auto px-4 py-3">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center space-x-2 cursor-pointer" onClick={() => setLocation("/")}>
-            <i className="fas fa-store text-blue-600 text-xl"></i>
+        <nav className="flex items-center justify-between" aria-label="Primary navigation">
+          <Link
+            href="/"
+            className="flex items-center space-x-2 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+            aria-label="Kanhaa home"
+          >
+            <i className="fas fa-store text-blue-600 text-xl" aria-hidden="true"></i>
             <h1 className="text-lg font-semibold text-gray-900">Kanhaa</h1>
-          </div>
+          </Link>
           <div className="flex items-center space-x-3">
             <UserMenu />
-            <button 
-              onClick={() => setLocation("/cart")}
-              className="relative p-2 text-gray-600 hover:text-blue-600 transition-colors"
+            <Link
+              href="/cart"
+              className="relative rounded p-2 text-gray-600 transition-colors hover:text-blue-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+              aria-label="View cart"
               data-testid="button-cart"
             >
-              <i className="fas fa-shopping-cart text-lg"></i>
+              <i className="fas fa-shopping-cart text-lg" aria-hidden="true"></i>
+              <span className="sr-only">Cart</span>
               {cartCount > 0 && (
                 <span className="absolute -top-1 -right-1 bg-red-600 text-white text-xs rounded-full h-5 w-5 flex items-center justify-center" data-testid="text-cart-count">
                   {cartCount}
                 </span>
               )}
-            </button>
+            </Link>
           </div>
-        </div>
+        </nav>
       </div>
     </header>
   );

--- a/client/src/pages/refund-policy.tsx
+++ b/client/src/pages/refund-policy.tsx
@@ -1,21 +1,20 @@
-import { Button } from "@/components/ui/button";
-import { useLocation } from "wouter";
+import { Link } from "wouter";
+
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 export default function RefundPolicy() {
-  const [, setLocation] = useLocation();
-
   return (
     <div className="max-w-4xl mx-auto py-8">
       <div className="mb-6">
-        <Button 
-          variant="ghost" 
-          onClick={() => setLocation("/")}
-          className="mb-4"
+        <Link
+          href="/"
+          className={cn(buttonVariants({ variant: "ghost" }), "mb-4")}
           data-testid="button-back-home"
         >
-          <i className="fas fa-arrow-left mr-2"></i>
+          <i className="fas fa-arrow-left mr-2" aria-hidden="true"></i>
           Back to Home
-        </Button>
+        </Link>
         <h1 className="text-3xl font-bold text-gray-900">Return / Refund / Cancellation Policy</h1>
       </div>
 

--- a/client/src/pages/terms-of-service.tsx
+++ b/client/src/pages/terms-of-service.tsx
@@ -1,21 +1,20 @@
-import { Button } from "@/components/ui/button";
-import { useLocation } from "wouter";
+import { Link } from "wouter";
+
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 export default function TermsOfService() {
-  const [, setLocation] = useLocation();
-
   return (
     <div className="max-w-4xl mx-auto py-8">
       <div className="mb-6">
-        <Button 
-          variant="ghost" 
-          onClick={() => setLocation("/")}
-          className="mb-4"
+        <Link
+          href="/"
+          className={cn(buttonVariants({ variant: "ghost" }), "mb-4")}
           data-testid="button-back-home"
         >
-          <i className="fas fa-arrow-left mr-2"></i>
+          <i className="fas fa-arrow-left mr-2" aria-hidden="true"></i>
           Back to Home
-        </Button>
+        </Link>
         <h1 className="text-3xl font-bold text-gray-900">Terms of Service</h1>
       </div>
 


### PR DESCRIPTION
## Summary
- replace header logo and cart buttons with semantic links inside a primary navigation container and preserve accessible focus styles
- update footer and policy page controls to use Wouter links with proper hrefs while keeping existing styling helpers for consistency

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68dd43992c04832a8d6558c5863ca2e7