### PR TITLE
Add sitemap endpoint and SEO robots directives

### DIFF
--- a/client/public/robots.txt
+++ b/client/public/robots.txt
@@ -1,0 +1,11 @@
+User-agent: *
+Disallow: /admin
+Disallow: /admin/
+Disallow: /influencer
+Disallow: /api/
+Disallow: /checkout
+Disallow: /payment
+Disallow: /thank-you
+Allow: /
+
+Sitemap: https://kanha.store/sitemap.xml

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -9,6 +9,8 @@ Both refactors improved maintainability but did not change **endpoint URLs** or 
 
 **Session security update (current change):** session cookies are now issued with `SameSite=Lax`, marked `secure` in production, and require the active secret to be sourced from a managed secrets provider. Rotation keeps prior secrets valid briefly, so buyer, admin, and influencer login flows continue working without interruption during key changes.
 
+**SEO sitemap addition (current change):** the storefront now exposes `/sitemap.xml` alongside a public `robots.txt` so search engines can index buyer-facing pages while continuing to block admin, influencer, checkout, and API surfaces. These read-only endpoints do not alter any user journey flows.
+
 ---
 
 ## Buyer Flow

--- a/package-lock.json
+++ b/package-lock.json
@@ -114,6 +114,7 @@
         "jsdom": "^27.0.0",
         "markdownlint-cli": "^0.45.0",
         "postcss": "^8.4.47",
+        "supertest": "^7.1.4",
         "tailwindcss": "^3.4.17",
         "tsx": "^4.19.1",
         "typescript": "5.6.3",
@@ -2650,6 +2651,19 @@
         "@types/pg": "8.11.6"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2683,6 +2697,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -6456,6 +6480,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -7004,6 +7035,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/connect-pg-simple": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/connect-pg-simple/-/connect-pg-simple-10.0.0.tgz",
@@ -7057,6 +7098,13 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cropperjs": {
@@ -7469,6 +7517,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/didyoumean": {
@@ -8660,6 +8719,13 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-xml-parser": {
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
@@ -8763,6 +8829,24 @@
       },
       "engines": {
         "node": ">= 0.12"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -13548,6 +13632,71 @@
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.2.3.tgz",
+      "integrity": "sha512-y/hkYGeXAj7wUMjxRbB21g/l6aAEituGXM9Rwl4o20+SX3e8YOSV6BxFXl+dL3Uk0mjSL3kCbNkwURm8/gEDig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.4",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.2"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.1.4.tgz",
+      "integrity": "sha512-tjLPs7dVyqgItVFirHYqe2T+MfWc2VOBQ8QFKKbWTA3PU7liZR8zoSpAi/C1k1ilm9RsXIKYf197oap9wXGVYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^10.2.3"
+      },
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "jsdom": "^27.0.0",
     "markdownlint-cli": "^0.45.0",
     "postcss": "^8.4.47",
+    "supertest": "^7.1.4",
     "tailwindcss": "^3.4.17",
     "tsx": "^4.19.1",
     "typescript": "5.6.3",

--- a/server/routes/__tests__/sitemap-and-robots.test.ts
+++ b/server/routes/__tests__/sitemap-and-robots.test.ts
@@ -1,0 +1,59 @@
+import express from "express";
+import path from "path";
+import request from "supertest";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createSitemapRouter } from "../sitemap";
+
+const getProductsMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../storage", () => ({
+  productsRepository: {
+    getProducts: getProductsMock,
+  },
+}));
+
+describe("seo endpoints", () => {
+  const originalBaseUrl = process.env.SITEMAP_BASE_URL;
+
+  beforeEach(() => {
+    getProductsMock.mockReset();
+    process.env.SITEMAP_BASE_URL = "https://kanha.store";
+  });
+
+  afterAll(() => {
+    process.env.SITEMAP_BASE_URL = originalBaseUrl;
+  });
+
+  it("returns a populated sitemap.xml", async () => {
+    getProductsMock.mockResolvedValue([
+      { id: "rose-tea" },
+      { id: "ginger-honey" },
+    ]);
+
+    const app = express();
+    app.use(createSitemapRouter());
+
+    const response = await request(app).get("/sitemap.xml");
+
+    expect(response.status).toBe(200);
+    expect(response.headers["content-type"]).toContain("application/xml");
+    expect(response.text).toContain("<loc>https://kanha.store</loc>");
+    expect(response.text).toContain("<loc>https://kanha.store/products</loc>");
+    expect(response.text).toContain("<loc>https://kanha.store/product/rose-tea</loc>");
+    expect(response.text).toContain("<loc>https://kanha.store/product/ginger-honey</loc>");
+  });
+
+  it("serves robots.txt with crawl directives", async () => {
+    const app = express();
+    const staticDir = path.resolve(import.meta.dirname, "../../..", "client", "public");
+    app.use(express.static(staticDir));
+
+    const response = await request(app).get("/robots.txt");
+
+    expect(response.status).toBe(200);
+    expect(response.text).toContain("User-agent: *");
+    expect(response.text).toContain("Disallow: /admin");
+    expect(response.text).toContain("Sitemap: https://kanha.store/sitemap.xml");
+  });
+});

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -19,6 +19,7 @@ import { createAnalyticsRouter, createCartAnalyticsRouter } from "./analytics";
 import { createAdminShippingRouter, createShippingRouter } from "./shipping";
 import { createSeedRouter } from "./seed";
 import { createPaymentsRouter } from "./payments";
+import { createSitemapRouter } from "./sitemap";
 import {
   EnvironmentSessionSecretsManager,
   SessionSecretRotator,
@@ -149,6 +150,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.use("/api/shipping", createShippingRouter());
   app.use("/api/payments", createPaymentsRouter(requireAdmin));
   app.use("/api/seed-accounts", createSeedRouter(requireAdmin));
+  app.use(createSitemapRouter());
 
   async function initializeDefaultSettings() {
     try {

--- a/server/routes/sitemap.ts
+++ b/server/routes/sitemap.ts
@@ -1,0 +1,58 @@
+import { Router } from "express";
+
+import { productsRepository } from "../storage";
+
+function normalizeBaseUrl(url: string): string {
+  return url.replace(/\/$/, "");
+}
+
+function buildAbsoluteUrl(baseUrl: string, path: string): string {
+  if (path === "/") {
+    return baseUrl;
+  }
+  return `${baseUrl}${path}`;
+}
+
+export function createSitemapRouter() {
+  const router = Router();
+
+  router.get("/sitemap.xml", async (_req, res) => {
+    try {
+      const configuredBaseUrl =
+        process.env.SITEMAP_BASE_URL || process.env.BASE_URL || "http://localhost:3000";
+      const baseUrl = normalizeBaseUrl(configuredBaseUrl);
+
+      const staticPaths = [
+        "/",
+        "/products",
+        "/cart",
+        "/checkout",
+        "/payment",
+        "/thank-you",
+        "/orders",
+      ];
+
+      const staticUrls = staticPaths.map((path) => buildAbsoluteUrl(baseUrl, path));
+
+      const products = await productsRepository.getProducts();
+      const productUrls = products.map((product) =>
+        `${baseUrl}/product/${encodeURIComponent(product.id)}`,
+      );
+
+      const uniqueUrls = Array.from(new Set([...staticUrls, ...productUrls]));
+
+      const urlEntries = uniqueUrls
+        .map((loc) => `  <url>\n    <loc>${loc}</loc>\n  </url>`)
+        .join("\n");
+
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urlEntries}\n</urlset>`;
+
+      res.type("application/xml").status(200).send(xml);
+    } catch (error) {
+      console.error("Failed to generate sitemap", error);
+      res.status(500).json({ message: "Failed to generate sitemap" });
+    }
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Summary
- add a public robots.txt with crawl directives and sitemap pointer for the storefront
- expose a /sitemap.xml endpoint that enumerates key storefront pages and active product URLs
- cover the new SEO endpoints with integration tests and note the addition in the user journey guide

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dd439ca0f0832a8fee0022a4fceca1