### PR TITLE
Add comprehensive SEO metadata to HTML entry point

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -2,8 +2,52 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kanhaa - Premium Nutrition Products</title>
+    <meta
+      name="description"
+      content="Kanhaa delivers premium nutrition supplements crafted to support holistic wellness, athletic performance, and everyday vitality."
+    />
+    <meta name="robots" content="index, follow" />
+    <meta property="og:title" content="Kanhaa - Premium Nutrition Products" />
+    <meta
+      property="og:description"
+      content="Discover Kanhaa's curated range of science-backed nutrition that fuels healthier lifestyles across India."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://www.kanhaa.com/" />
+    <meta property="og:image" content="https://www.kanhaa.com/assets/kanhaa-og-image.jpg" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Kanhaa - Premium Nutrition Products" />
+    <meta
+      name="twitter:description"
+      content="Explore premium nutrition made by Kanhaa to empower your wellness journey."
+    />
+    <meta name="twitter:image" content="https://www.kanhaa.com/assets/kanhaa-og-image.jpg" />
+    <link rel="canonical" href="https://www.kanhaa.com/" />
+    <link rel="icon" type="image/png" sizes="32x32" href="https://www.kanhaa.com/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="https://www.kanhaa.com/favicon-16x16.png" />
+    <link rel="apple-touch-icon" href="https://www.kanhaa.com/apple-touch-icon.png" />
+    <link rel="manifest" href="https://www.kanhaa.com/site.webmanifest" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "name": "Kanhaa",
+        "url": "https://www.kanhaa.com/",
+        "logo": "https://www.kanhaa.com/apple-touch-icon.png",
+        "contactPoint": [
+          {
+            "@type": "ContactPoint",
+            "telephone": "+91-9890894335",
+            "contactType": "customer service",
+            "email": "support@kanhaa.com",
+            "areaServed": "IN",
+            "availableLanguage": ["en"]
+          }
+        ]
+      }
+    </script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,6 +98,7 @@
         "@testing-library/jest-dom": "^6.9.0",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
+        "@types/bcryptjs": "^2.4.6",
         "@types/connect-pg-simple": "^7.0.3",
         "@types/express": "4.17.21",
         "@types/express-session": "^1.18.0",
@@ -5455,6 +5456,13 @@
       "dependencies": {
         "@babel/types": "^7.20.7"
       }
+    },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "@testing-library/jest-dom": "^6.9.0",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
+    "@types/bcryptjs": "^2.4.6",
     "@types/connect-pg-simple": "^7.0.3",
     "@types/express": "4.17.21",
     "@types/express-session": "^1.18.0",


### PR DESCRIPTION
## Summary
- expand the client entrypoint head with production-ready SEO, social, and accessibility metadata
- add organization JSON-LD and favicon references so downstream builds emit the enriched markup
- install the @types/bcryptjs dev dependency to keep the TypeScript project checks passing after the update

## Testing
- npm run build
- npm run check
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd438d331c832aa2bbae164122e4db