### PR TITLE
Update products page heading hierarchy

### DIFF
--- a/client/src/pages/products.tsx
+++ b/client/src/pages/products.tsx
@@ -18,10 +18,10 @@ export default function Products() {
   if (isLoading) {
     return (
       <div className="space-y-6">
-        <div className="mb-6">
+        <header className="mb-6">
           <div className="h-8 bg-gray-200 rounded w-48 mb-2 animate-pulse"></div>
           <div className="h-4 bg-gray-200 rounded w-64 animate-pulse"></div>
-        </div>
+        </header>
         <div className="grid grid-cols-2 lg:grid-cols-3 gap-6">
           {Array(6).fill(0).map((_, i) => (
             <div key={i} className="bg-white rounded-lg shadow-sm overflow-hidden">
@@ -44,10 +44,10 @@ export default function Products() {
   if (error) {
     return (
       <div className="space-y-6">
-        <div className="mb-6">
-          <h2 className="text-2xl font-semibold text-gray-900 mb-2">Our Products</h2>
+        <header className="mb-6">
+          <h1 className="text-3xl font-semibold text-gray-900 mb-2">Our Products</h1>
           <p className="text-gray-600">Discover our carefully curated collection</p>
-        </div>
+        </header>
         <ApiErrorMessage error={error as Error} onRetry={() => refetch()} />
       </div>
     );
@@ -83,11 +83,10 @@ export default function Products() {
           </div>
         </div>
       )}
-
-      <div className="mb-6">
-        <h2 className="text-2xl font-semibold text-gray-900 mb-2">Our Products</h2>
+      <header className="mb-6">
+        <h1 className="text-3xl font-semibold text-gray-900 mb-2">Our Products</h1>
         <p className="text-gray-600">Discover our carefully curated collection</p>
-      </div>
+      </header>
 
       {!products || products.length === 0 ? (
         <div className="text-center py-12">


### PR DESCRIPTION
## Summary
- promote the Products page heading to an <h1> to improve semantic structure
- wrap the heading area in a semantic <header> element for consistency across loading and error states

## Testing
- npm run test *(fails: server/storage/__tests__/users-repository.test.ts cannot find package 'bcryptjs')*

------
https://chatgpt.com/codex/tasks/task_e_68dd43a2aa34832ab835a84b427b626d