### PR TITLE
Regenerate sessions across login handlers

### DIFF
--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -32,6 +32,7 @@ Both refactors improved maintainability but did not change **endpoint URLs** or 
 3. **Authenticate with OTP**
    - `POST /api/auth/send-otp`, `POST /api/auth/login` in `server/routes/auth.ts`, backed by `usersRepository`.
    - Successful login attaches buyer context to session.
+   - Sessions now regenerate on every successful login (OTP or password) to prevent fixation while retaining the shopper's cart tracking token so baskets persist across authentication.
    - Password-based fallbacks (where configured for returning buyers) now hash credentials with bcrypt and transparently upgrade legacy plaintext entries the first time a buyer logs in, so there is no change to the checkout experience.
 
 4. **Manage Addresses**  
@@ -80,6 +81,7 @@ Both refactors improved maintainability but did not change **endpoint URLs** or 
 1. **Authentication**
    - `/api/admin/login` handled in `server/routes/admin.ts`, backed by `usersRepository`.
    - `requireAdmin` middleware from `server/routes/index.ts` protects routes.
+   - Admin sessions regenerate on login before role data is stored, preserving the existing cart-tracking token while ensuring fresh session identifiers.
    - Admin passwords are now stored as bcrypt hashes. Legacy plaintext credentials are rehashed automatically on successful login, keeping the dashboard sign-in flow unchanged while hardening storage.
    - Asset uploads via `POST /api/objects/upload` now rely on the same admin session guard, denying anonymous callers signed upload URLs.
 
@@ -123,6 +125,7 @@ Both refactors improved maintainability but did not change **endpoint URLs** or 
 ## Influencer Flow
 1. **Authentication**
    - Influencer login/profile handled by `server/routes/influencers.ts`, backed by `usersRepository`.
+   - Sessions regenerate on influencer login to prevent fixation and immediately persist the influencer context for downstream analytics and order lookups.
    - Password authentication now verifies bcrypt hashes and upgrades any remaining plaintext passwords during the next successful login without altering the influencer portal UX.
    - Self-serve influencer operations (login/logout/profile) live under `/api/influencer` and require an authenticated influencer session.
 

--- a/server/routes/__tests__/session-regeneration.test.ts
+++ b/server/routes/__tests__/session-regeneration.test.ts
@@ -1,0 +1,231 @@
+import express from "express";
+import session from "express-session";
+import request from "supertest";
+import type { SuperAgentTest } from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createAuthRouter } from "../auth";
+import { createAdminRouter } from "../admin";
+import { createInfluencerAuthRouter } from "../influencers";
+import type { RequireAdminMiddleware, SessionRequest } from "../types";
+
+const verifyOtpMock = vi.hoisted(() => vi.fn());
+const authenticateAdminMock = vi.hoisted(() => vi.fn());
+const authenticateInfluencerMock = vi.hoisted(() => vi.fn());
+const authenticateUserMock = vi.hoisted(() => vi.fn());
+const validateAdminLoginMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../otp-service", () => ({
+  otpService: {
+    verifyOtp: verifyOtpMock,
+    sendOtp: vi.fn(),
+  },
+}));
+
+vi.mock("../../storage", () => ({
+  ordersRepository: {
+    getOrders: vi.fn(),
+    getOrdersByUser: vi.fn(),
+  },
+  settingsRepository: {
+    getAppSettings: vi.fn(),
+    updateAppSetting: vi.fn(),
+  },
+  usersRepository: {
+    authenticateAdmin: authenticateAdminMock,
+    authenticateInfluencer: authenticateInfluencerMock,
+    authenticateUser: authenticateUserMock,
+    createAdmin: vi.fn(),
+    createInfluencer: vi.fn(),
+    deactivateInfluencer: vi.fn(),
+    getAdmin: vi.fn(),
+    getAdmins: vi.fn(),
+    getInfluencer: vi.fn(),
+    getInfluencers: vi.fn(),
+    getUser: vi.fn(),
+    getUserAddresses: vi.fn().mockResolvedValue([]),
+    createUserAddress: vi.fn(),
+    setPreferredAddress: vi.fn(),
+    deleteUserAddress: vi.fn(),
+    validateAdminLogin: validateAdminLoginMock,
+  },
+}));
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    session({
+      secret: "test-secret",
+      resave: false,
+      saveUninitialized: false,
+    }),
+  );
+
+  app.use((req, _res, next) => {
+    const sessionReq = req as SessionRequest;
+    if (!sessionReq.session.sessionId) {
+      sessionReq.session.sessionId = `sess_${Math.random().toString(36).slice(2)}`;
+    }
+    next();
+  });
+
+  app.get("/session-info", (req, res) => {
+    const sessionReq = req as SessionRequest;
+    res.json({
+      sessionId: req.sessionID,
+      cartSessionId: sessionReq.session.sessionId ?? null,
+      adminId: sessionReq.session.adminId ?? null,
+      influencerId: sessionReq.session.influencerId ?? null,
+      userId: sessionReq.session.userId ?? null,
+      role: sessionReq.session.userRole ?? null,
+    });
+  });
+
+  const requireAdmin: RequireAdminMiddleware = (_req, _res, next) => next();
+
+  app.use("/api/auth", createAuthRouter());
+  app.use("/api/admin", createAdminRouter(requireAdmin));
+  app.use("/api/influencer", createInfluencerAuthRouter());
+
+  return app;
+};
+
+const getSessionSnapshot = async (agent: SuperAgentTest) => {
+  const response = await agent.get("/session-info");
+  expect(response.status).toBe(200);
+  return response.body as {
+    sessionId: string;
+    cartSessionId: string | null;
+    adminId: string | null;
+    influencerId: string | null;
+    userId: string | null;
+    role: string | null;
+  };
+};
+
+describe("session regeneration on login", () => {
+  beforeEach(() => {
+    verifyOtpMock.mockReset();
+    authenticateAdminMock.mockReset();
+    authenticateInfluencerMock.mockReset();
+    authenticateUserMock.mockReset();
+    validateAdminLoginMock.mockReset();
+  });
+
+  it("rotates the session id when a buyer logs in with OTP", async () => {
+    verifyOtpMock.mockResolvedValueOnce({
+      success: true,
+      user: { id: "buyer-1" },
+      isNewUser: false,
+      message: "OK",
+    });
+
+    const app = buildApp();
+    const agent = request.agent(app);
+
+    const anonymousSession = await getSessionSnapshot(agent);
+    const response = await agent.post("/api/auth/login").send({ phone: "9876543210", otp: "123456" });
+
+    expect(response.status).toBe(200);
+
+    const authenticatedSession = await getSessionSnapshot(agent);
+    expect(authenticatedSession.sessionId).not.toBe(anonymousSession.sessionId);
+    expect(authenticatedSession.cartSessionId).toBe(anonymousSession.cartSessionId);
+    expect(authenticatedSession.userId).toBe("buyer-1");
+    expect(authenticatedSession.role).toBe("buyer");
+  });
+
+  it("rotates the session id when verifying an admin OTP", async () => {
+    verifyOtpMock.mockResolvedValueOnce({
+      success: true,
+      user: { id: "admin-42" },
+      isNewUser: false,
+      message: "OK",
+    });
+
+    const app = buildApp();
+    const agent = request.agent(app);
+
+    const anonymousSession = await getSessionSnapshot(agent);
+    const response = await agent
+      .post("/api/auth/verify-otp")
+      .send({ phone: "9876543210", otp: "654321", userType: "admin" });
+
+    expect(response.status).toBe(200);
+
+    const authenticatedSession = await getSessionSnapshot(agent);
+    expect(authenticatedSession.sessionId).not.toBe(anonymousSession.sessionId);
+    expect(authenticatedSession.cartSessionId).toBe(anonymousSession.cartSessionId);
+    expect(authenticatedSession.adminId).toBe("admin-42");
+    expect(authenticatedSession.role).toBe("admin");
+  });
+
+  it("rotates the session id for password logins", async () => {
+    authenticateUserMock.mockResolvedValueOnce({ id: "buyer-55" });
+
+    const app = buildApp();
+    const agent = request.agent(app);
+
+    const anonymousSession = await getSessionSnapshot(agent);
+    const response = await agent
+      .post("/api/auth/login-password")
+      .send({ phone: "9998887776", password: "secret", userType: "buyer" });
+
+    expect(response.status).toBe(200);
+
+    const authenticatedSession = await getSessionSnapshot(agent);
+    expect(authenticatedSession.sessionId).not.toBe(anonymousSession.sessionId);
+    expect(authenticatedSession.cartSessionId).toBe(anonymousSession.cartSessionId);
+    expect(authenticatedSession.userId).toBe("buyer-55");
+    expect(authenticatedSession.role).toBe("buyer");
+  });
+
+  it("rotates the session id on admin login", async () => {
+    validateAdminLoginMock.mockResolvedValueOnce({
+      id: "admin-1",
+      username: "admin",
+      name: "Site Admin",
+    });
+
+    const app = buildApp();
+    const agent = request.agent(app);
+
+    const anonymousSession = await getSessionSnapshot(agent);
+    const response = await agent
+      .post("/api/admin/login")
+      .send({ username: "admin", password: "password" });
+
+    expect(response.status).toBe(200);
+
+    const authenticatedSession = await getSessionSnapshot(agent);
+    expect(authenticatedSession.sessionId).not.toBe(anonymousSession.sessionId);
+    expect(authenticatedSession.cartSessionId).toBe(anonymousSession.cartSessionId);
+    expect(authenticatedSession.adminId).toBe("admin-1");
+    expect(authenticatedSession.role).toBe("admin");
+  });
+
+  it("rotates the session id on influencer login", async () => {
+    authenticateInfluencerMock.mockResolvedValueOnce({
+      id: "influencer-9",
+      phone: "8887776665",
+      name: "Creator",
+    });
+
+    const app = buildApp();
+    const agent = request.agent(app);
+
+    const anonymousSession = await getSessionSnapshot(agent);
+    const response = await agent
+      .post("/api/influencer/login")
+      .send({ phone: "8887776665", password: "hunter2" });
+
+    expect(response.status).toBe(200);
+
+    const authenticatedSession = await getSessionSnapshot(agent);
+    expect(authenticatedSession.sessionId).not.toBe(anonymousSession.sessionId);
+    expect(authenticatedSession.cartSessionId).toBe(anonymousSession.cartSessionId);
+    expect(authenticatedSession.influencerId).toBe("influencer-9");
+    expect(authenticatedSession.role).toBe("influencer");
+  });
+});

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -55,7 +55,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   const sessionConfig = session({
     secret: sessionSecrets,
     resave: false,
-    saveUninitialized: true,
+    saveUninitialized: false,
     cookie: {
       secure: isProduction,
       sameSite: "lax",

--- a/server/utils/session.ts
+++ b/server/utils/session.ts
@@ -1,0 +1,25 @@
+import type { SessionRequest } from "../routes/types";
+
+export async function regenerateSession(req: SessionRequest): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    req.session.regenerate(err => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+export async function saveSession(req: SessionRequest): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    req.session.save(err => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve();
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- regenerate Express sessions for buyer, admin, and influencer authentication routes before setting role context and persist the state with `req.session.save`
- add utilities for session regeneration, disable `saveUninitialized`, and document the regenerated-session behavior in the user journey guide
- add regression tests that confirm session identifiers rotate on OTP, password, admin, and influencer logins

## Testing
- npm run check
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd53160008832a848c1d24be738c17