### PR TITLE
Add safe migration for orders payment_failed_at column

### DIFF
--- a/migrations/0009_orders_payment_failed_at_safe.sql
+++ b/migrations/0009_orders_payment_failed_at_safe.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "orders"
+ADD COLUMN IF NOT EXISTS "payment_failed_at" timestamp;


### PR DESCRIPTION
## Summary
- add a migration that safely ensures the `orders.payment_failed_at` column exists by using `IF NOT EXISTS`

## Testing
- npm run check
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68de6cb1f8b0832ab0a1d8c379f8bd78