### PR TITLE
Fix checkout shipping validation during cart load

### DIFF
--- a/client/src/pages/checkout.tsx
+++ b/client/src/pages/checkout.tsx
@@ -35,7 +35,7 @@ const EMPTY_USER_INFO: UserInfo = {
 export default function Checkout() {
   const [, setLocation] = useLocation();
   const { toast } = useToast();
-  const { cartItems, subtotal, clearCart } = useCart();
+  const { cartItems, subtotal, clearCart, isLoading: isCartLoading } = useCart();
   const [step, setStep] = useState<"phone" | "otp" | "details">("phone");
   const [phone, setPhone] = useState("");
   const [otp, setOtp] = useState("");
@@ -57,7 +57,17 @@ export default function Checkout() {
 
   // Function to calculate shipping charges
   const calculateShipping = useCallback(async (pincode: string) => {
-    if (!validatePincode(pincode) || cartItems.length === 0) {
+    if (!validatePincode(pincode)) {
+      setShippingCharge(50); // Default fallback
+      setIsPincodeValid(false);
+      return;
+    }
+
+    if (cartItems.length === 0) {
+      if (isCartLoading) {
+        return;
+      }
+
       setShippingCharge(50); // Default fallback
       setIsPincodeValid(false);
       return;
@@ -80,7 +90,7 @@ export default function Checkout() {
     } finally {
       setIsCalculatingShipping(false);
     }
-  }, [cartItems, subtotal, validatePincode]);
+  }, [cartItems, isCartLoading, subtotal, validatePincode]);
 
   // Check if user is already logged in
   const { data: authData } = useQuery<{ authenticated: boolean; user?: any }>({

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -46,6 +46,7 @@ Both refactors improved maintainability but did not change **endpoint URLs** or 
    - Enriches order with addresses, offers, and shipping rules using domain repositories.
    - Orders now persist the selected `paymentMethod` while defaulting both `status` and `paymentStatus` to `pending` until the gateway confirms payment, allowing retries without losing cart context.
    - The checkout UI automatically selects the buyer's preferred address, recalculates shipping for that PIN code, and keeps the preferred record untouched when shoppers add a fresh address during the flow.
+   - Checkout now waits for cart data to finish loading before treating an auto-populated PIN as invalid, so buyers with a preferred address keep the place-order button enabled while items hydrate in the background.
    - Newly added addresses are now used for the in-flight order even when the shopper chooses not to mark them as preferred, eliminating the previous edge case where one-off deliveries defaulted back to the prior preferred address.
    - Payment capture events atomically mark orders as confirmed/paid and store gateway identifiers (PhonePe merchant transaction ID, provider transaction ID, UTR, payer handle, and a receipt link) so post-checkout experiences surface accurate payment evidence.
    - Incoming PhonePe callbacks/webhooks now reconcile the captured amount against the original authorization, logging and suppressing mismatched payloads while still acknowledging replays so buyers never see duplicate confirmations from tampered notifications.


### PR DESCRIPTION
## Summary
- ensure checkout reads the cart loading state and avoids invalidating preferred PINs while data hydrates
- return early from shipping calculation when the cart is still loading and update the callback dependencies accordingly
- document that checkout now waits for cart hydration before disabling the place-order button

## Testing
- npm run check
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dec65d81dc832a8357322a2990b808