### PR TITLE
Allow button text wrapping with optional nowrap prop

### DIFF
--- a/client/src/components/layout/user-menu.tsx
+++ b/client/src/components/layout/user-menu.tsx
@@ -53,6 +53,7 @@ export default function UserMenu() {
           size="sm"
           onClick={() => setShowLoginModal(true)}
           className="flex items-center gap-2"
+          noWrap
           data-testid="button-login"
         >
           <User className="h-4 w-4" />
@@ -72,7 +73,13 @@ export default function UserMenu() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="sm" className="flex items-center gap-2" data-testid="button-user-menu">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="flex items-center gap-2"
+          data-testid="button-user-menu"
+          noWrap
+        >
           <User className="h-4 w-4" />
           <span className="hidden sm:inline">{user?.name || user?.phone || 'User'}</span>
         </Button>

--- a/client/src/components/ui/button.tsx
+++ b/client/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -37,14 +37,18 @@ export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean
+  /**
+   * Keeps button text on a single line when `true`.
+   */
+  noWrap?: boolean
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
+  ({ className, variant, size, asChild = false, noWrap = false, ...props }, ref) => {
     const Comp = asChild ? Slot : "button"
     return (
       <Comp
-        className={cn(buttonVariants({ variant, size, className }))}
+        className={cn(buttonVariants({ variant, size }), noWrap && "whitespace-nowrap", className)}
         ref={ref}
         {...props}
       />


### PR DESCRIPTION
## Summary
- allow the shared Button component to wrap text by default while offering a noWrap escape hatch
- keep user menu buttons single-line by applying the new noWrap prop where layout depends on it

## Testing
- npm run test
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68e0be719fcc832aaea84415576634bc